### PR TITLE
fix: resolve Next.js outputFileTracingRoot warning in monorepo build

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,8 @@
 import type { NextConfig } from "next";
+import path from "path";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  outputFileTracingRoot: path.join(__dirname, "../../"),
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Fixes the Next.js build warning about multiple lockfiles by setting `outputFileTracingRoot` in `next.config.ts` to point to the monorepo root.

## Changes

- Set `outputFileTracingRoot` in `apps/web/next.config.ts` to resolve the workspace root detection warning

## Before
```
⚠ Warning: Next.js inferred your workspace root, but it may not be correct.
We detected multiple lockfiles...
```

## After
Clean build with zero warnings and zero errors for both `@getwired/web` and `getwired` CLI.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author