### PR TITLE
feat: Add Electron desktop app testing support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2938,7 +2938,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3637,6 +3636,36 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {
@@ -4496,6 +4525,7 @@
         "@napi-rs/canvas": "^0.1.65",
         "commander": "^13.0.0",
         "ink": "^6.8.0",
+        "playwright": "^1.59.1",
         "react": "^19.0.0"
       },
       "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,16 +40,17 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "ink": "^6.8.0",
-    "react": "^19.0.0",
+    "@napi-rs/canvas": "^0.1.65",
     "commander": "^13.0.0",
-    "@napi-rs/canvas": "^0.1.65"
+    "ink": "^6.8.0",
+    "playwright": "^1.59.1",
+    "react": "^19.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
-    "typescript": "^5.7.0",
     "tsup": "^8.4.0",
-    "tsx": "^4.19.0"
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -29,7 +29,7 @@ program
   .option("--scope <scope>", "Scope of testing (e.g. auth, checkout, navigation)")
   .option("--persona <mode>", "Test persona: standard, hacky, or old-man", "standard")
   .option("-d, --device <profile>", "Device profile: desktop, mobile, or both", "both")
-  .option("--platform <platform>", "Native emulator platform: android or ios (uses emulator instead of browser)")
+  .option("--platform <platform>", "Test platform: android, ios, or electron (uses native automation instead of browser)")
   .option("--provider <provider>", "Override AI provider for this run")
   .action((options) => {
     render(<RunCommand options={options} />);

--- a/packages/cli/src/components/App.tsx
+++ b/packages/cli/src/components/App.tsx
@@ -8,18 +8,22 @@ import { TestProgress } from "./TestProgress.js";
 import { initConfig, configExists, loadConfig, saveConfig, getReportDir, getMemoryPath } from "../config/settings.js";
 import { getRegressionContext } from "../git/context.js";
 import { getAvailableProviders } from "../providers/registry.js";
-import { getLocalAppUrlError, isLocalAppUrl, runTestSession, runNativeTestSession } from "../orchestrator/index.js";
+import { getLocalAppUrlError, isLocalAppUrl, runTestSession, runNativeTestSession, runDesktopTestSession } from "../orchestrator/index.js";
 import { ProviderStream } from "./ProviderStream.js";
 import { readFile, readdir, rm, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { GetwiredSettings } from "../config/settings.js";
 import type { DeviceProfile, TestFinding, TestPersona, TestReport, NativePlatform } from "../providers/types.js";
+import type { DesktopPlatform } from "../desktop/types.js";
 import type { TestStep, TestPhase } from "../orchestrator/index.js";
 import type { PrerequisiteCheck } from "../emulator/types.js";
+import type { DesktopPrerequisiteCheck } from "../desktop/types.js";
 import { clearAndroidSdkInfoCache } from "../emulator/android-sdk.js";
 import { checkAndroidPrerequisites, checkIosPrerequisites } from "../emulator/detect.js";
+import { checkElectronPrerequisites } from "../desktop/detect.js";
 import { installNativeTestDependencies } from "../emulator/ensure-dependencies.js";
+import { installDesktopDependencies } from "../desktop/ensure-dependencies.js";
 
 const INSTALL_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -130,11 +134,20 @@ export function App({ mode, initProvider }: AppProps) {
   // Native emulator
   const [nativePlatform, setNativePlatform] = useState<NativePlatform>("android");
   const [nativePlatformIndex, setNativePlatformIndex] = useState(0);
-  const [nativeCheckResult, setNativeCheckResult] = useState<PrerequisiteCheck | null>(null);
+  const [nativeCheckResult, setNativeCheckResult] = useState<PrerequisiteCheck | DesktopPrerequisiteCheck | null>(null);
   const [nativeCheckLoading, setNativeCheckLoading] = useState(false);
   const [nativeInstallLoading, setNativeInstallLoading] = useState(false);
   const [nativeInstallError, setNativeInstallError] = useState<string | null>(null);
   const [nativeInstallTick, setNativeInstallTick] = useState(0);
+
+  function getPlatformLabel(platform: NativePlatform | DesktopPlatform): string {
+    switch (platform) {
+      case "android": return "🤖 Android";
+      case "ios": return "🍎 iOS";
+      case "electron": return "⚡ Electron";
+      default: return platform;
+    }
+  }
 
   const providers = getAvailableProviders();
   const selectedInitProvider = providers[providerIndex];
@@ -254,16 +267,21 @@ export function App({ mode, initProvider }: AppProps) {
     return savedUrl && isLocalAppUrl(savedUrl) ? savedUrl : "";
   }
 
-  function hasNativeAutoFixableIssues(result: PrerequisiteCheck | null): boolean {
+  function hasNativeAutoFixableIssues(result: PrerequisiteCheck | DesktopPrerequisiteCheck | null): boolean {
     return !!result?.issues.some((issue) => !issue.passed && issue.autoFixable);
   }
 
-  async function getPrerequisiteCheck(platform: NativePlatform): Promise<PrerequisiteCheck> {
+  async function getPrerequisiteCheck(platform: NativePlatform | DesktopPlatform): Promise<PrerequisiteCheck | DesktopPrerequisiteCheck> {
     if (platform === "android") {
       clearAndroidSdkInfoCache();
       return checkAndroidPrerequisites(process.cwd());
     }
-
+    if (platform === "ios") {
+      return checkIosPrerequisites(process.cwd());
+    }
+    if (platform === "electron") {
+      return checkElectronPrerequisites();
+    }
     return checkIosPrerequisites(process.cwd());
   }
 
@@ -294,7 +312,13 @@ export function App({ mode, initProvider }: AppProps) {
     setNativeInstallError(null);
 
     try {
-      const installResult = await installNativeTestDependencies(platform, process.cwd());
+      const DESKTOP_PLATS = ["electron"];
+      let installResult;
+      if (DESKTOP_PLATS.includes(platform)) {
+        installResult = await installDesktopDependencies(platform as any);
+      } else {
+        installResult = await installNativeTestDependencies(platform, process.cwd());
+      }
       if (!installResult.ok) {
         setNativeInstallError(installResult.error ?? "Auto-install failed.");
         return;
@@ -525,9 +549,9 @@ export function App({ mode, initProvider }: AppProps) {
       case "native-platform":
         if (key.escape || input === "b") { setView("dashboard"); return; }
         if (key.upArrow) setNativePlatformIndex((p) => Math.max(0, p - 1));
-        if (key.downArrow) setNativePlatformIndex((p) => Math.min(1, p + 1));
+        if (key.downArrow) setNativePlatformIndex((p) => Math.min(NATIVE_PLATFORMS.length - 1, p + 1));
         if (key.return) {
-          const platform: NativePlatform = nativePlatformIndex === 0 ? "android" : "ios";
+          const platform = NATIVE_PLATFORMS[nativePlatformIndex].id as NativePlatform;
           setNativePlatform(platform);
           setNativeCheckLoading(true);
           setView("native-check");
@@ -1043,7 +1067,7 @@ export function App({ mode, initProvider }: AppProps) {
             <Text color="greenBright" bold>◆ Choose a platform to test on:</Text>
             <Box flexDirection="column" marginY={1}>
               {NATIVE_PLATFORMS.map((p, i) => (
-                <Box key={p.id} gap={1}>
+                <Box key={p.id} gap={1} marginBottom={i < NATIVE_PLATFORMS.length - 1 ? 1 : 0}>
                   <Text color={i === nativePlatformIndex ? "greenBright" : "green"}>
                     {i === nativePlatformIndex ? " ▸ " : "   "}
                   </Text>
@@ -1066,7 +1090,7 @@ export function App({ mode, initProvider }: AppProps) {
       {/* ── Native: Prerequisite Check ── */}
       {view === "native-check" && (
         <>
-          <Header subtitle={`Native App Test · ${nativePlatform === "android" ? "🤖 Android" : "🍎 iOS"}`} />
+          <Header subtitle={`Native App Test · ${getPlatformLabel(nativePlatform)}`} />
           <Box flexDirection="column" paddingX={2} gap={1}>
             {nativeCheckLoading && (
               <Text color="greenBright">⏳ Checking prerequisites...</Text>
@@ -1128,7 +1152,7 @@ export function App({ mode, initProvider }: AppProps) {
 
       {view === "native-install-confirm" && nativeCheckResult && (
         <>
-          <Header subtitle={`Native App Test · ${nativePlatform === "android" ? "🤖 Android" : "🍎 iOS"}`} />
+          <Header subtitle={`Native App Test · ${getPlatformLabel(nativePlatform)}`} />
           <Box flexDirection="column" paddingX={2} gap={1}>
             <Text color="yellowBright" bold>◆ Native automation install required</Text>
             <Text color="green" dimColor>
@@ -1170,7 +1194,7 @@ export function App({ mode, initProvider }: AppProps) {
       {/* ── Native: Mode Select (reuses test-mode pattern) ── */}
       {view === "native-mode" && (
         <>
-          <Header subtitle={`Native App Test · ${nativePlatform === "android" ? "🤖 Android" : "🍎 iOS"}`} />
+          <Header subtitle={`Native App Test · ${getPlatformLabel(nativePlatform)}`} />
           <Box flexDirection="column" paddingX={2} gap={1}>
             <Text color="greenBright" bold>◆ Choose the kind of test run:</Text>
             <Box flexDirection="column" marginY={1}>
@@ -1198,7 +1222,7 @@ export function App({ mode, initProvider }: AppProps) {
       {/* ── Native: URL/Scope Input ── */}
       {view === "native-url" && (
         <>
-          <Header subtitle={`Native App Test · ${nativePlatform === "android" ? "🤖 Android" : "🍎 iOS"} · ${getTestPersonaLabel(selectedTestPersona)}`} />
+          <Header subtitle={`Native App Test · ${getPlatformLabel(nativePlatform)} · ${getTestPersonaLabel(selectedTestPersona)}`} />
           <Box flexDirection="column" paddingX={2} gap={1}>
             {getConfiguredLocalUrl() && (
               <Text color="green" dimColor>Target: {getConfiguredLocalUrl()}</Text>
@@ -1226,22 +1250,41 @@ export function App({ mode, initProvider }: AppProps) {
                 setTestUrl(url);
                 setActiveTestPersona(selectedTestPersona);
                 setView("native-running");
-                runNativeTestSession(
-                  process.cwd(),
-                  {
-                    url: url || undefined,
-                    scope: testScope,
-                    persona: selectedTestPersona,
-                    nativePlatform,
-                  },
-                  {
-                    onPhaseChange: (p, msg) => { setTestPhase(p); setTestPhaseMsg(msg); },
-                    onStepUpdate: (s) => setTestSteps([...s]),
-                    onFinding: (f) => setTestFindings((prev) => [...prev, f]),
-                    onLog: (msg) => setTestLogs((prev) => [...prev, msg].slice(-10)),
-                    onProviderOutput: appendProviderOutput,
-                  },
-                )
+                const DESKTOP_PLATS = ["electron"];
+                const sessionPromise = DESKTOP_PLATS.includes(nativePlatform)
+                  ? runDesktopTestSession(
+                      process.cwd(),
+                      {
+                        url: url || undefined,
+                        scope: testScope,
+                        persona: selectedTestPersona,
+                        desktopPlatform: nativePlatform as any,
+                      },
+                      {
+                        onPhaseChange: (p, msg) => { setTestPhase(p); setTestPhaseMsg(msg); },
+                        onStepUpdate: (s) => setTestSteps([...s]),
+                        onFinding: (f) => setTestFindings((prev) => [...prev, f]),
+                        onLog: (msg) => setTestLogs((prev) => [...prev, msg].slice(-10)),
+                        onProviderOutput: appendProviderOutput,
+                      },
+                    )
+                  : runNativeTestSession(
+                      process.cwd(),
+                      {
+                        url: url || undefined,
+                        scope: testScope,
+                        persona: selectedTestPersona,
+                        nativePlatform,
+                      },
+                      {
+                        onPhaseChange: (p, msg) => { setTestPhase(p); setTestPhaseMsg(msg); },
+                        onStepUpdate: (s) => setTestSteps([...s]),
+                        onFinding: (f) => setTestFindings((prev) => [...prev, f]),
+                        onLog: (msg) => setTestLogs((prev) => [...prev, msg].slice(-10)),
+                        onProviderOutput: appendProviderOutput,
+                      },
+                    );
+                sessionPromise
                   .then((r) => setTestReport(r))
                   .catch((err) => setTestError(String(err)));
               }}
@@ -1260,8 +1303,8 @@ export function App({ mode, initProvider }: AppProps) {
         <>
           <Header subtitle={
             testUrl
-              ? `Native App Test · ${nativePlatform === "android" ? "🤖 Android" : "🍎 iOS"} · ${getTestPersonaLabel(activeTestPersona)} · ${testUrl}`
-              : `Native App Test · ${nativePlatform === "android" ? "🤖 Android" : "🍎 iOS"} · ${getTestPersonaLabel(activeTestPersona)}`
+              ? `Native App Test · ${getPlatformLabel(nativePlatform)} · ${getTestPersonaLabel(activeTestPersona)} · ${testUrl}`
+              : `Native App Test · ${getPlatformLabel(nativePlatform)} · ${getTestPersonaLabel(activeTestPersona)}`
           } />
           <StatusBar status={statusMap[testPhase] ?? "testing"} message={testPhaseMsg} />
           <Box flexDirection="row" marginY={1} minHeight={20} width="100%">
@@ -1592,6 +1635,7 @@ const MENU_ITEMS = [
 const NATIVE_PLATFORMS = [
   { id: "android", label: "Android", icon: "🤖", description: "Test on Android Emulator (requires Android SDK)" },
   { id: "ios", label: "iOS", icon: "🍎", description: "Test on iOS Simulator (requires Xcode, macOS only)" },
+  { id: "electron", label: "Electron", icon: "⚡", description: "Test Electron desktop app (requires Appium)" },
 ];
 
 const SETTINGS_SECTIONS = [

--- a/packages/cli/src/components/RunCommand.tsx
+++ b/packages/cli/src/components/RunCommand.tsx
@@ -4,9 +4,15 @@ import { Header } from "./Header.js";
 import { StatusBar } from "./StatusBar.js";
 import { TestProgress } from "./TestProgress.js";
 import { ProviderStream } from "./ProviderStream.js";
-import { runTestSession, runNativeTestSession } from "../orchestrator/index.js";
+import { runTestSession, runNativeTestSession, runDesktopTestSession } from "../orchestrator/index.js";
 import type { TestStep, TestPhase } from "../orchestrator/index.js";
 import type { NativePlatform, TestFinding, TestPersona, TestReport } from "../providers/types.js";
+import type { DesktopPlatform } from "../desktop/types.js";
+
+const DESKTOP_PLATFORMS: string[] = ["electron"];
+function isDesktopPlatform(p: string): p is DesktopPlatform {
+  return DESKTOP_PLATFORMS.includes(p);
+}
 
 interface RunCommandProps {
   options: {
@@ -16,7 +22,7 @@ interface RunCommandProps {
     scope?: string;
     persona?: TestPersona;
     device?: string;
-    platform?: NativePlatform;
+    platform?: NativePlatform | DesktopPlatform;
     provider?: string;
     baselineOnly?: boolean;
   };
@@ -46,32 +52,43 @@ export function RunCommand({ options }: RunCommandProps) {
       onProviderOutput: (text: string) => setProviderOutput((prev) => prev + text),
     };
 
-    const session = options.platform
-      ? runNativeTestSession(
-        projectPath,
-        {
-          url: options.url,
-          scope: options.scope,
-          persona: options.persona,
-          nativePlatform: options.platform,
-        },
-        callbacks,
-      )
-      : runTestSession(
-        projectPath,
-        {
-          url: options.url,
-          commitId: options.commit,
-          prId: options.pr,
-          scope: options.scope,
-          persona: options.persona,
-        },
-        callbacks,
-      );
+    const session = options.platform && isDesktopPlatform(options.platform)
+      ? runDesktopTestSession(
+          projectPath,
+          {
+            url: options.url,
+            scope: options.scope,
+            persona: options.persona,
+            desktopPlatform: options.platform,
+          },
+          callbacks,
+        )
+      : options.platform
+        ? runNativeTestSession(
+            projectPath,
+            {
+              url: options.url,
+              scope: options.scope,
+              persona: options.persona,
+              nativePlatform: options.platform,
+            },
+            callbacks,
+          )
+        : runTestSession(
+            projectPath,
+            {
+              url: options.url,
+              commitId: options.commit,
+              prId: options.pr,
+              scope: options.scope,
+              persona: options.persona,
+            },
+            callbacks,
+          );
 
     session
-      .then((r) => setReport(r))
-      .catch((err) => setError(String(err)));
+      .then((r: TestReport) => setReport(r))
+      .catch((err: unknown) => setError(String(err)));
   }, []);
 
   const statusMap: Record<TestPhase, "idle" | "testing" | "analyzing" | "reporting" | "error"> = {
@@ -94,7 +111,7 @@ export function RunCommand({ options }: RunCommandProps) {
     : options.pr
       ? `Regression · PR #${options.pr}`
       : options.platform
-        ? `Native ${options.platform === "ios" ? "iOS" : "Android"} · ${options.url ?? "Launch app"}`
+        ? `${options.platform === "ios" ? "iOS" : options.platform === "android" ? "Android" : "Electron"} · ${options.url ?? "Launch app"}`
       : options.baselineOnly
         ? "Capturing Baselines"
         : options.persona && options.persona !== "standard"

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -49,6 +49,12 @@ export interface GetwiredSettings {
       workingDirectory?: string;
       source?: string;
     };
+    electron?: {
+      appPath?: string;
+      launchCommand?: string;
+      workingDirectory?: string;
+      source?: string;
+    };
   };
   testing: {
     deviceProfile: DeviceProfile;
@@ -89,6 +95,7 @@ const DEFAULT_SETTINGS: GetwiredSettings = {
   native: {
     ios: {},
     android: {},
+    electron: {},
   },
   testing: {
     deviceProfile: "both",
@@ -194,6 +201,10 @@ export async function loadConfig(projectPath: string): Promise<GetwiredSettings>
       android: {
         ...DEFAULT_SETTINGS.native.android,
         ...(saved.native?.android ?? {}),
+      },
+      electron: {
+        ...DEFAULT_SETTINGS.native.electron,
+        ...(saved.native?.electron ?? {}),
       },
     },
     testing: {

--- a/packages/cli/src/desktop/desktop-actions.ts
+++ b/packages/cli/src/desktop/desktop-actions.ts
@@ -1,0 +1,200 @@
+import type { DesktopPlatform } from "./types.js";
+
+// ─── Desktop Action Registry ────────────────────────────────────
+// Defines all available desktop actions per platform. Used to:
+// 1. Generate accurate prompts for AI providers
+// 2. Validate AI-generated scenarios at parse time
+// 3. Keep prompts in sync with actual executor capabilities
+
+export interface DesktopActionDef {
+  type: string;
+  description: string;
+  platforms: DesktopPlatform[];
+  params: {
+    selector?: string;
+    value?: string;
+    key?: string;
+    url?: string;
+  };
+  examples: string[];
+}
+
+const ACTIONS: DesktopActionDef[] = [
+  {
+    type: "tap",
+    description: "Click a desktop element using CSS selector or XPath.",
+    platforms: ["electron"],
+    params: { selector: "Element selector (CSS/XPath for Electron)" },
+    examples: [
+      '{ "type": "tap", "selector": "button[type=\\"submit\\"]", "description": "Click submit button" }',
+    ],
+  },
+  {
+    type: "click",
+    description: "Alias for tap. Click a desktop element using CSS selector or XPath.",
+    platforms: ["electron"],
+    params: { selector: "Element selector (CSS/XPath for Electron)" },
+    examples: [
+      '{ "type": "click", "selector": "#login-button", "description": "Click login button" }',
+    ],
+  },
+  {
+    type: "fill",
+    description: "Click an input field and type text into it using CSS selector or XPath.",
+    platforms: ["electron"],
+    params: {
+      selector: "Input field selector (CSS/XPath for Electron)",
+      value: "Text to type into the field",
+    },
+    examples: [
+      '{ "type": "fill", "selector": "input[name=\\"email\\"]", "value": "test@example.com", "description": "Enter email" }',
+    ],
+  },
+  {
+    type: "select",
+    description: "Select an option in a dropdown/select element. Electron only (web-based select elements).",
+    platforms: ["electron"],
+    params: {
+      selector: "CSS selector or XPath for the select element",
+      value: "Value or text of the option to select",
+    },
+    examples: [
+      '{ "type": "select", "selector": "select[name=\\"country\\"]", "value": "US", "description": "Select country" }',
+    ],
+  },
+  {
+    type: "scroll",
+    description: "Scroll the window or element. Positive value = scroll down, negative = scroll up.",
+    platforms: ["electron"],
+    params: { value: "Scroll distance in pixels (positive=down, negative=up). Default: 600" },
+    examples: [
+      '{ "type": "scroll", "value": "600", "description": "Scroll down to see more content" }',
+      '{ "type": "scroll", "value": "-400", "description": "Scroll back up" }',
+    ],
+  },
+  {
+    type: "keyboard",
+    description: "Press a keyboard key. Common keys: Enter, Tab, Escape, Backspace, Delete, ArrowUp, ArrowDown, ArrowLeft, ArrowRight.",
+    platforms: ["electron"],
+    params: { key: "Key name: Enter, Tab, Escape, Backspace, Delete, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, etc." },
+    examples: [
+      '{ "type": "keyboard", "key": "Enter", "description": "Submit the form" }',
+      '{ "type": "keyboard", "key": "Tab", "description": "Move to next field" }',
+    ],
+  },
+  {
+    type: "wait",
+    description: "Wait for a specified duration in milliseconds (max 5000ms) to let animations or loading complete.",
+    platforms: ["electron"],
+    params: { value: "Duration in milliseconds (e.g. 1000 for 1 second)" },
+    examples: [
+      '{ "type": "wait", "value": "2000", "description": "Wait for content to load" }',
+    ],
+  },
+  {
+    type: "assert",
+    description: "Assert that an element with the given selector is visible on screen.",
+    platforms: ["electron"],
+    params: { selector: "Element selector (CSS/XPath for Electron)" },
+    examples: [
+      '{ "type": "assert", "selector": "h1.welcome", "description": "Verify welcome message" }',
+    ],
+  },
+  {
+    type: "navigate",
+    description: "Navigate to a URL (Electron only, for web-based navigation within the app).",
+    platforms: ["electron"],
+    params: { url: "URL to navigate to (e.g. https://example.com or app://route)" },
+    examples: [
+      '{ "type": "navigate", "url": "https://example.com/dashboard", "description": "Navigate to dashboard" }',
+    ],
+  },
+  {
+    type: "screenshot",
+    description: "Capture the current screen state as a PNG screenshot for evidence.",
+    platforms: ["electron"],
+    params: {},
+    examples: [
+      '{ "type": "screenshot", "description": "Capture current screen state" }',
+    ],
+  },
+];
+
+export function getActionsForPlatform(platform: DesktopPlatform): DesktopActionDef[] {
+  return ACTIONS.filter((action) => action.platforms.includes(platform));
+}
+
+export function getValidActionTypes(platform: DesktopPlatform): Set<string> {
+  return new Set(getActionsForPlatform(platform).map((a) => a.type));
+}
+
+export function isValidAction(type: string, platform: DesktopPlatform): boolean {
+  return getValidActionTypes(platform).has(type);
+}
+
+export function buildDesktopActionPrompt(platform: DesktopPlatform): string {
+  const actions = getActionsForPlatform(platform);
+  
+  const platformLabels: Record<DesktopPlatform, string> = {
+    electron: "Electron",
+  };
+  
+  const platformLabel = platformLabels[platform];
+
+  const lines: string[] = [
+    `## Available Desktop Actions (${platformLabel})`,
+    "",
+    "You MUST only use action types from this list. Any other action type will be rejected.",
+    "",
+  ];
+
+  for (const action of actions) {
+    lines.push(`### \`${action.type}\``);
+    lines.push(action.description);
+    const paramEntries = Object.entries(action.params);
+    if (paramEntries.length > 0) {
+      lines.push("Parameters:");
+      for (const [key, desc] of paramEntries) {
+        lines.push(`  - \`${key}\`: ${desc}`);
+      }
+    }
+    lines.push(`Example: ${action.examples[0]}`);
+    lines.push("");
+  }
+
+  lines.push("## Action JSON Format");
+  lines.push("");
+  lines.push("Return scenarios as a JSON array:");
+  lines.push("```");
+  lines.push('[{ "name": "Scenario name", "category": "happy-path|edge-case|abuse|boundary|error-recovery",');
+  lines.push('   "actions": [{ "type": "<action-type>", "selector": "...", "value": "...", "key": "...", "url": "...", "description": "What you are doing and why" }] }]');
+  lines.push("```");
+  lines.push("");
+  lines.push("CRITICAL RULES:");
+  lines.push("- ONLY use action types listed above. Do NOT invent new action types.");
+  
+  if (platform === "electron") {
+    lines.push("- For `tap`, `click`, `fill`, and `assert`: use CSS selectors or XPath expressions.");
+    lines.push("- Prefer stable selectors like `#id`, `[data-testid=...]`, `[name=...]`, `[aria-label=...]`.");
+    lines.push("- The app is already open. Do NOT start with a navigate action unless testing a specific URL.");
+  }
+  
+  lines.push("- For `scroll`: use pixel values (positive=down, negative=up). Typical scroll distance is ~600px.");
+  lines.push("- Include at least one `screenshot` action per scenario for evidence.");
+  lines.push("- Return ONLY raw JSON. No markdown fences, no prose.");
+
+  return lines.join("\n");
+}
+
+export function validateDesktopScenarioActions<T extends { actions: Array<{ type: string }> }>(
+  scenarios: T[],
+  platform: DesktopPlatform,
+): T[] {
+  const validTypes = getValidActionTypes(platform);
+  return scenarios
+    .map((scenario) => ({
+      ...scenario,
+      actions: scenario.actions.filter((action) => validTypes.has(action.type)),
+    }))
+    .filter((scenario) => scenario.actions.length > 0);
+}

--- a/packages/cli/src/desktop/desktop-launch.ts
+++ b/packages/cli/src/desktop/desktop-launch.ts
@@ -1,0 +1,330 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import type { GetwiredSettings } from "../config/settings.js";
+import type {
+  DesktopPlatform,
+  ResolvedDesktopLaunchTarget,
+  ResolvedElectronLaunchTarget,
+} from "./types.js";
+
+const IGNORED_DIRS = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "coverage",
+  "node_modules",
+]);
+
+interface DesktopLaunchMemoryHints {
+  electron: {
+    appPath?: string;
+    launchCommand?: string;
+    workingDirectory?: string;
+    source?: string;
+  };
+}
+
+interface DetectedCandidate {
+  value: string;
+  detectedFrom: string;
+  confidence: number;
+  launchCommand?: string;
+  workingDirectory?: string;
+}
+
+export function parseDesktopLaunchMemory(memory: string): DesktopLaunchMemoryHints {
+  const hints: DesktopLaunchMemoryHints = {
+    electron: {},
+  };
+  if (!memory) return hints;
+
+  const sectionMatch = memory.match(/## Desktop Launch\n([\s\S]*?)(?=\n## |\n*$)/);
+  if (!sectionMatch) return hints;
+
+  const lines = sectionMatch[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "));
+
+  for (const line of lines) {
+    const match = line.match(/^- ([a-z]+)\.([a-zA-Z]+):\s*(.+)$/);
+    if (!match) continue;
+    const [, platform, key, value] = match;
+    if (platform !== "electron") continue;
+
+    const target = hints[platform as keyof DesktopLaunchMemoryHints];
+    switch (key) {
+      case "appPath":
+      case "launchCommand":
+      case "workingDirectory":
+      case "source":
+        (target as Record<string, string | undefined>)[key] = value.trim();
+        break;
+      default:
+        break;
+    }
+  }
+
+  return hints;
+}
+
+export function upsertDesktopLaunchMemory(
+  memory: string,
+  target: ResolvedDesktopLaunchTarget,
+): string {
+  const hints = parseDesktopLaunchMemory(memory);
+
+  if (target.platform === "electron") {
+    hints.electron.appPath = target.appPath;
+    hints.electron.launchCommand = target.launchCommand;
+    hints.electron.workingDirectory = target.workingDirectory;
+    hints.electron.source = target.detectedFrom;
+  }
+
+  const sectionLines = ["## Desktop Launch"];
+
+  if (hints.electron.appPath) sectionLines.push(`- electron.appPath: ${hints.electron.appPath}`);
+  if (hints.electron.launchCommand) sectionLines.push(`- electron.launchCommand: ${hints.electron.launchCommand}`);
+  if (hints.electron.workingDirectory) sectionLines.push(`- electron.workingDirectory: ${hints.electron.workingDirectory}`);
+  if (hints.electron.source) sectionLines.push(`- electron.source: ${hints.electron.source}`);
+
+  const newSection = `${sectionLines.join("\n")}\n`;
+
+  if (!memory.trim()) return `${newSection}\n`;
+
+  if (/## Desktop Launch\n/.test(memory)) {
+    return memory.replace(/## Desktop Launch\n[\s\S]*?(?=\n## |\n*$)/, newSection.trimEnd());
+  }
+
+  const trimmed = memory.trimEnd();
+  return `${trimmed}\n\n${newSection}`;
+}
+
+export function persistDesktopLaunchTarget(
+  settings: GetwiredSettings,
+  target: ResolvedDesktopLaunchTarget,
+): GetwiredSettings {
+  const native = settings.native ?? { ios: {}, android: {}, electron: {} };
+
+  if (target.platform === "electron") {
+    return {
+      ...settings,
+      native: {
+        ...native,
+        electron: {
+          ...native.electron,
+          appPath: target.appPath,
+          launchCommand: target.launchCommand ?? native.electron?.launchCommand,
+          workingDirectory: target.workingDirectory ?? native.electron?.workingDirectory,
+          source: target.detectedFrom,
+        },
+      },
+    };
+  }
+
+  return settings;
+}
+
+export async function resolveDesktopLaunchTarget(
+  platform: DesktopPlatform,
+  projectDir: string,
+  settings: GetwiredSettings,
+  memory?: string,
+  options?: { skipCache?: boolean },
+): Promise<ResolvedDesktopLaunchTarget> {
+  const memoryHints = memory ? parseDesktopLaunchMemory(memory) : { electron: {} };
+  const configHints = settings.native ?? { ios: {}, android: {}, electron: {} };
+
+  if (!options?.skipCache && platform === "electron") {
+    if (memoryHints.electron.appPath) {
+      return {
+        platform: "electron",
+        appPath: memoryHints.electron.appPath,
+        launchCommand: memoryHints.electron.launchCommand ?? configHints.electron?.launchCommand,
+        workingDirectory: memoryHints.electron.workingDirectory ?? configHints.electron?.workingDirectory,
+        source: "memory",
+        detectedFrom: memoryHints.electron.source ?? "memory",
+      };
+    }
+    if (configHints.electron?.appPath) {
+      return {
+        platform: "electron",
+        appPath: configHints.electron.appPath,
+        launchCommand: configHints.electron.launchCommand,
+        workingDirectory: configHints.electron.workingDirectory,
+        source: "config",
+        detectedFrom: configHints.electron.source ?? ".getwired/config.json",
+      };
+    }
+  }
+
+  const detected = await inspectProjectDesktopLaunchTarget(projectDir, platform);
+  if (!detected) {
+    const configPath = ".getwired/config.json";
+    throw new Error(
+      `Unable to determine which Electron app to launch. Add native.electron.appPath to ${configPath} or ensure your project has detectable Electron configuration.`,
+    );
+  }
+
+  const electronDetected = detected as DetectedCandidate;
+  return {
+    platform: "electron",
+    appPath: electronDetected.value,
+    launchCommand: electronDetected.launchCommand ?? memoryHints.electron.launchCommand ?? configHints.electron?.launchCommand,
+    workingDirectory: electronDetected.workingDirectory ?? memoryHints.electron.workingDirectory ?? configHints.electron?.workingDirectory,
+    source: "project",
+    detectedFrom: electronDetected.detectedFrom,
+  };
+}
+
+export function describeDesktopLaunchTarget(target: ResolvedDesktopLaunchTarget): string {
+  const commandSummary = target.launchCommand
+    ? `; command ${target.launchCommand}${target.workingDirectory ? ` @ ${target.workingDirectory}` : ""}`
+    : "";
+
+  return `electron ${target.appPath} (${target.detectedFrom}${commandSummary})`;
+}
+
+async function inspectProjectDesktopLaunchTarget(
+  projectDir: string,
+  platform: DesktopPlatform,
+): Promise<DetectedCandidate | undefined> {
+  if (platform === "electron") {
+    return await detectElectronLaunchTarget(projectDir);
+  }
+  return undefined;
+}
+
+async function detectElectronLaunchTarget(projectDir: string): Promise<DetectedCandidate | undefined> {
+  const packageJsonPath = join(projectDir, "package.json");
+  if (!existsSync(packageJsonPath)) return undefined;
+
+  const parsed = await safeReadJson(packageJsonPath) as Record<string, unknown> | undefined;
+  if (!parsed || typeof parsed !== "object") return undefined;
+
+  const dependencies = {
+    ...(typeof parsed.dependencies === "object" && parsed.dependencies ? parsed.dependencies : {}),
+    ...(typeof parsed.devDependencies === "object" && parsed.devDependencies ? parsed.devDependencies : {}),
+  } as Record<string, string>;
+
+  const hasElectron = Boolean(
+    dependencies.electron
+    || dependencies["electron-builder"]
+    || dependencies["@electron-forge/cli"]
+    || dependencies["@electron-forge/core"]
+  );
+
+  if (!hasElectron) return undefined;
+
+  const mainField = typeof parsed.main === "string" ? parsed.main : "index.js";
+  const scriptsObj = typeof parsed.scripts === "object" && parsed.scripts ? parsed.scripts as Record<string, unknown> : {};
+
+  let launchCommand: string | undefined;
+  let workingDirectory: string | undefined;
+
+  const electronScripts = ["start", "electron", "electron:start", "dev"];
+  for (const scriptName of electronScripts) {
+    if (typeof scriptsObj[scriptName] === "string") {
+      launchCommand = `npm run ${scriptName}`;
+      workingDirectory = ".";
+      break;
+    }
+  }
+
+  const buildDirs = ["dist", "out", "release", "build"];
+  for (const buildDir of buildDirs) {
+    const buildPath = join(projectDir, buildDir);
+    if (existsSync(buildPath)) {
+      const appPath = await findElectronAppInDir(buildPath);
+      if (appPath) {
+        return {
+          value: appPath,
+          detectedFrom: `${buildDir}/`,
+          launchCommand,
+          workingDirectory: workingDirectory ?? ".",
+          confidence: 90,
+        };
+      }
+    }
+  }
+
+  return {
+    value: join(projectDir, mainField),
+    detectedFrom: "package.json main field",
+    launchCommand,
+    workingDirectory: workingDirectory ?? ".",
+    confidence: 80,
+  };
+}
+
+async function findElectronAppInDir(dir: string): Promise<string | undefined> {
+  if (!existsSync(dir)) return undefined;
+
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (entry.name.endsWith(".app")) {
+        return join(dir, entry.name);
+      }
+      if (process.platform === "win32" && entry.name.endsWith("-win")) {
+        const exePath = await findExeInDir(join(dir, entry.name));
+        if (exePath) return exePath;
+      }
+    }
+    if (entry.isFile() && entry.name.endsWith(".exe")) {
+      return join(dir, entry.name);
+    }
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory() && !IGNORED_DIRS.has(entry.name)) {
+      const found = await findElectronAppInDir(join(dir, entry.name));
+      if (found) return found;
+    }
+  }
+
+  return undefined;
+}
+
+async function findExeInDir(dir: string): Promise<string | undefined> {
+  if (!existsSync(dir)) return undefined;
+
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith(".exe")) {
+      return join(dir, entry.name);
+    }
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory() && !IGNORED_DIRS.has(entry.name)) {
+      const found = await findExeInDir(join(dir, entry.name));
+      if (found) return found;
+    }
+  }
+
+  return undefined;
+}
+
+async function safeReadJson(filePath: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(filePath, "utf-8"));
+  } catch {
+    return undefined;
+  }
+}
+
+async function safeReadText(filePath: string): Promise<string> {
+  try {
+    return await readFile(filePath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function normalizeSlashes(value: string): string {
+  return value.split("\\").join("/");
+}

--- a/packages/cli/src/desktop/detect.ts
+++ b/packages/cli/src/desktop/detect.ts
@@ -1,0 +1,55 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { DesktopPlatform, DesktopPrerequisiteCheck, DesktopDevice, PrerequisiteIssue } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+async function execSafe(cmd: string, args: string[], timeout = 10_000): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(cmd, args, { encoding: "utf-8", timeout });
+    return stdout.trim();
+  } catch {
+    return "";
+  }
+}
+
+async function hasNodeCommand(): Promise<boolean> {
+  const result = await execSafe("node", ["--version"]);
+  return result.length > 0;
+}
+
+export async function checkElectronPrerequisites(): Promise<DesktopPrerequisiteCheck> {
+  const issues: PrerequisiteIssue[] = [];
+  const devices: DesktopDevice[] = [];
+
+  const hasNode = await hasNodeCommand();
+  issues.push({
+    check: "Node.js installed",
+    passed: hasNode,
+    hint: hasNode ? undefined : "Install Node.js from https://nodejs.org",
+  });
+
+  const hasPlaywright = await execSafe("npx", ["playwright", "--version"]);
+  const hasPlaywrightBool = hasPlaywright.length > 0;
+  issues.push({
+    check: "Playwright installed",
+    passed: hasPlaywrightBool,
+    autoFixable: !hasPlaywrightBool,
+    hint: hasPlaywrightBool ? undefined : "Install Playwright: npm install playwright",
+  });
+
+  const available = issues.every((i) => i.passed);
+  const canProceed = issues.every((i) => i.passed || i.autoFixable);
+  return { platform: "electron", available, canProceed, issues, devices };
+}
+
+export async function checkDesktopPrerequisites(platform: DesktopPlatform): Promise<DesktopPrerequisiteCheck> {
+  if (platform === "electron") {
+    return checkElectronPrerequisites();
+  }
+  
+  const issues: PrerequisiteIssue[] = [
+    { check: `Unknown platform: ${platform}`, passed: false },
+  ];
+  return { platform: platform as "electron", available: false, issues, devices: [] };
+}

--- a/packages/cli/src/desktop/electron-app.ts
+++ b/packages/cli/src/desktop/electron-app.ts
@@ -1,0 +1,229 @@
+import { _electron as electron, type ElectronApplication, type Page } from "playwright";
+import type { ResolvedElectronLaunchTarget } from "./types.js";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export interface ElectronSession {
+  app: ElectronApplication;
+  page: Page;
+}
+
+function findElectronBinary(projectDir: string): string | undefined {
+  // Check common locations for the electron binary
+  const candidates = [
+    join(projectDir, "node_modules", ".bin", "electron"),
+    join(projectDir, "node_modules", "electron", "dist", "Electron.app", "Contents", "MacOS", "Electron"), // macOS
+    join(projectDir, "node_modules", "electron", "dist", "electron"), // Linux
+    join(projectDir, "node_modules", "electron", "dist", "electron.exe"), // Windows
+  ];
+  
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  
+  return undefined;
+}
+
+async function getActiveWindow(app: ElectronApplication): Promise<Page> {
+  // Get all windows and pick the last one (most recently created = likely the main window)
+  const windows = app.windows();
+  
+  if (windows.length === 0) {
+    // No windows yet — wait for one to appear
+    const page = await app.waitForEvent("window", { timeout: 15000 });
+    await page.waitForLoadState("domcontentloaded").catch(() => {});
+    // Give the page a moment to render
+    await new Promise((r) => setTimeout(r, 1000));
+    return page;
+  }
+  
+  // Pick the last window (most recent) that isn't closed
+  for (let i = windows.length - 1; i >= 0; i--) {
+    const win = windows[i];
+    try {
+      // Test if the window is still alive by checking the URL
+      await win.url();
+      await win.waitForLoadState("domcontentloaded").catch(() => {});
+      return win;
+    } catch {
+      // Window is closed, try the next one
+      continue;
+    }
+  }
+  
+  // All windows closed — wait for a new one
+  const page = await app.waitForEvent("window", { timeout: 15000 });
+  await page.waitForLoadState("domcontentloaded").catch(() => {});
+  await new Promise((r) => setTimeout(r, 1000));
+  return page;
+}
+
+async function ensureActivePage(session: ElectronSession): Promise<Page> {
+  try {
+    // Quick check if the current page is still alive
+    await session.page.url();
+    return session.page;
+  } catch {
+    // Page is closed — get the new active window
+    const page = await getActiveWindow(session.app);
+    session.page = page;
+    return page;
+  }
+}
+
+export async function launchElectronApp(target: ResolvedElectronLaunchTarget): Promise<ElectronSession> {
+  const projectDir = target.workingDirectory || process.cwd();
+  const electronPath = findElectronBinary(projectDir);
+  
+  if (!electronPath) {
+    throw new Error(
+      `Electron binary not found in ${projectDir}/node_modules. \n` +
+      `Make sure the target project has electron installed: cd ${projectDir} && npm install\n` +
+      `Or install electron as a dev dependency: cd ${projectDir} && npm install -D electron`
+    );
+  }
+  
+  const app = await electron.launch({
+    executablePath: electronPath,
+    args: [target.appPath],
+    cwd: projectDir,
+  });
+  
+  // Wait for the app to stabilize — Electron apps often create/destroy windows during startup
+  // Give the app time to finish initialization
+  await new Promise((r) => setTimeout(r, 3000));
+  
+  // Get the most recent window (the main window, not a splash screen)
+  const page = await getActiveWindow(app);
+  
+  return { app, page };
+}
+
+export async function captureElectronScreenshot(session: ElectronSession): Promise<Buffer> {
+  const page = await ensureActivePage(session);
+  const buffer = await page.screenshot();
+  return Buffer.from(buffer);
+}
+
+export async function getElectronUIStructure(session: ElectronSession): Promise<string> {
+  const page = await ensureActivePage(session);
+  const snapshot = await page.evaluate(() => {
+    const normalizeText = (value: unknown) => (value || "").toString().trim().replace(/\s+/g, " ").slice(0, 80);
+    const toXPathLiteral = (value: string | null) => {
+      if (!value) return null;
+      if (!value.includes("'")) return "'" + value + "'";
+      if (!value.includes('"')) return '"' + value + '"';
+      return null;
+    };
+
+    const selectorFor = (element: Element) => {
+      const attrNames = ["data-testid", "data-test", "data-qa", "id", "name", "aria-label", "placeholder"];
+      for (const attr of attrNames) {
+        const value = element.getAttribute(attr);
+        if (!value) continue;
+        if (attr === "id") return "#" + CSS.escape(value);
+        return "[" + attr + "=\"" + value.replace(/"/g, '\\"') + "\"]";
+      }
+      if (element.tagName === "A" && element.getAttribute("href")) {
+        return "a[href=\"" + element.getAttribute("href")!.replace(/"/g, '\\"') + "\"]";
+      }
+      return null;
+    };
+
+    const xpathFor = (element: Element) => {
+      const text = normalizeText((element as HTMLElement).innerText || element.textContent || "");
+      const role = element.getAttribute("role");
+      const roleLiteral = toXPathLiteral(role);
+      const textLiteral = toXPathLiteral(text);
+      if (roleLiteral && textLiteral) {
+        return "//*[@role=" + roleLiteral + " and normalize-space(.)=" + textLiteral + "]";
+      }
+      if (element.tagName === "BUTTON" && textLiteral) {
+        return "//button[normalize-space(.)=" + textLiteral + "]";
+      }
+      if (element.tagName === "A" && textLiteral) {
+        return "//a[normalize-space(.)=" + textLiteral + "]";
+      }
+      const placeholder = element.getAttribute("placeholder");
+      const placeholderLiteral = toXPathLiteral(placeholder);
+      if ((element.tagName === "INPUT" || element.tagName === "TEXTAREA") && placeholderLiteral) {
+        return "//" + element.tagName.toLowerCase() + "[@placeholder=" + placeholderLiteral + "]";
+      }
+      return null;
+    };
+
+    const collect = (selector: string) => Array.from(document.querySelectorAll(selector))
+      .slice(0, 40)
+      .map((element) => {
+        const cssSelector = selectorFor(element);
+        const xpathSelector = xpathFor(element);
+        return {
+          tag: element.tagName.toLowerCase(),
+          text: normalizeText((element as HTMLElement).innerText || element.textContent || ""),
+          selector: cssSelector || xpathSelector,
+          selectorCandidates: Array.from(new Set([cssSelector, xpathSelector].filter(Boolean))).slice(0, 3),
+          role: element.getAttribute("role") || undefined,
+          name: element.getAttribute("name") || undefined,
+          ariaLabel: element.getAttribute("aria-label") || undefined,
+          placeholder: element.getAttribute("placeholder") || undefined,
+          href: element.getAttribute("href") || undefined,
+          type: element.getAttribute("type") || undefined,
+        };
+      });
+
+    return {
+      url: window.location.href,
+      title: document.title,
+      readyState: document.readyState,
+      textSnippet: (document.body?.innerText || "").replace(/\s+/g, " ").slice(0, 2000),
+      buttons: collect("button, [role=button]"),
+      links: collect("a[href]"),
+      inputs: collect("input, textarea"),
+      selects: collect("select"),
+      forms: collect("form"),
+      iframes: Array.from(document.querySelectorAll("iframe"))
+        .slice(0, 20)
+        .map((frame) => ({
+          src: frame.getAttribute("src") || undefined,
+          title: frame.getAttribute("title") || undefined,
+        })),
+    };
+  });
+  
+  const snapshotJson = JSON.stringify(snapshot, null, 2);
+  const title = await page.title();
+  const url = page.url();
+  
+  return `Page: ${title}\nURL: ${url}\n\nAccessibility Tree:\n${snapshotJson}`;
+}
+
+export async function getElectronPageHTML(session: ElectronSession): Promise<string> {
+  const page = await ensureActivePage(session);
+  return page.content();
+}
+
+export async function clickElectronElement(session: ElectronSession, selector: string): Promise<void> {
+  const page = await ensureActivePage(session);
+  await page.click(selector);
+}
+
+export async function fillElectronElement(session: ElectronSession, selector: string, value: string): Promise<void> {
+  const page = await ensureActivePage(session);
+  await page.fill(selector, value);
+}
+
+export async function pressElectronKey(session: ElectronSession, key: string): Promise<void> {
+  const page = await ensureActivePage(session);
+  await page.keyboard.press(key);
+}
+
+export async function scrollElectron(session: ElectronSession, distance: number): Promise<void> {
+  const page = await ensureActivePage(session);
+  await page.mouse.wheel(0, distance);
+}
+
+export async function closeElectronApp(session: ElectronSession): Promise<void> {
+  await session.app.close();
+}

--- a/packages/cli/src/desktop/ensure-dependencies.ts
+++ b/packages/cli/src/desktop/ensure-dependencies.ts
@@ -1,0 +1,19 @@
+import { execSync } from "node:child_process";
+import type { DesktopPlatform } from "./types.js";
+
+interface InstallResult {
+  ok: boolean;
+  error?: string;
+}
+
+export async function installDesktopDependencies(platform: DesktopPlatform): Promise<InstallResult> {
+  if (platform === "electron") {
+    try {
+      execSync("npm install playwright", { stdio: "pipe" });
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: `Failed to install playwright: ${String(err)}` };
+    }
+  }
+  return { ok: false, error: `Unsupported platform: ${platform}` };
+}

--- a/packages/cli/src/desktop/types.ts
+++ b/packages/cli/src/desktop/types.ts
@@ -1,0 +1,34 @@
+export type DesktopPlatform = "electron";
+
+export interface DesktopDevice {
+  id: string;
+  name: string;
+  platform: DesktopPlatform;
+  state: "available" | "unavailable" | "unknown";
+}
+
+export interface PrerequisiteIssue {
+  check: string;
+  passed: boolean;
+  hint?: string;
+  autoFixable?: boolean;
+}
+
+export interface DesktopPrerequisiteCheck {
+  platform: DesktopPlatform;
+  available: boolean;
+  canProceed?: boolean;
+  issues: PrerequisiteIssue[];
+  devices: DesktopDevice[];
+}
+
+export interface ResolvedElectronLaunchTarget {
+  platform: "electron";
+  appPath: string;
+  launchCommand?: string;
+  workingDirectory?: string;
+  source: "memory" | "config" | "project";
+  detectedFrom: string;
+}
+
+export type ResolvedDesktopLaunchTarget = ResolvedElectronLaunchTarget;

--- a/packages/cli/src/emulator/appium.ts
+++ b/packages/cli/src/emulator/appium.ts
@@ -157,9 +157,9 @@ export async function listInstalledAppiumDrivers(): Promise<string[]> {
 
 export async function hasRequiredAppiumDriver(platform: NativePlatform): Promise<boolean> {
   const drivers = await listInstalledAppiumDrivers();
-  return platform === "ios"
-    ? drivers.includes("xcuitest")
-    : drivers.includes("uiautomator2");
+  if (platform === "ios") return drivers.includes("xcuitest");
+  if (platform === "android") return drivers.includes("uiautomator2");
+  return false;
 }
 
 export async function installAppiumServer(): Promise<{ ok: boolean; error?: string }> {
@@ -175,7 +175,14 @@ export async function installAppiumDriver(platform: NativePlatform): Promise<{ o
     return { ok: false, error: "The `appium` command is not available yet." };
   }
   await mkdir(APPIUM_HOME, { recursive: true });
-  const driverName = platform === "ios" ? "xcuitest" : "uiautomator2";
+  let driverName: string;
+  if (platform === "ios") {
+    driverName = "xcuitest";
+  } else if (platform === "android") {
+    driverName = "uiautomator2";
+  } else {
+    return { ok: false, error: `Unsupported platform: ${platform}` };
+  }
   if (await hasRequiredAppiumDriver(platform)) {
     return { ok: true };
   }
@@ -825,7 +832,7 @@ function parseInstalledDriverNames(raw: string): string[] {
   }
 
   const names = new Set<string>();
-  for (const match of trimmed.matchAll(/\b(xcuitest|uiautomator2)\b/gi)) {
+  for (const match of trimmed.matchAll(/\b(xcuitest|uiautomator2|mac2|windows)\b/gi)) {
     names.add(match[1].toLowerCase());
   }
   for (const match of trimmed.matchAll(/^\s*[-•*]?\s*([a-z0-9-]+)\s*(?:@|$)/gim)) {
@@ -842,14 +849,14 @@ function collectDriverNames(value: unknown, names: Set<string>): void {
   }
   if (typeof value === "object") {
     for (const [key, item] of Object.entries(value)) {
-      if (/^(xcuitest|uiautomator2)$/i.test(key)) {
+      if (/^(xcuitest|uiautomator2|mac2|windows)$/i.test(key)) {
         names.add(key.toLowerCase());
       }
       collectDriverNames(item, names);
     }
     return;
   }
-  if (typeof value === "string" && /^(xcuitest|uiautomator2)$/i.test(value.trim())) {
+  if (typeof value === "string" && /^(xcuitest|uiautomator2|mac2|windows)$/i.test(value.trim())) {
     names.add(value.trim().toLowerCase());
   }
 }

--- a/packages/cli/src/emulator/types.ts
+++ b/packages/cli/src/emulator/types.ts
@@ -1,4 +1,5 @@
 export type NativePlatform = "android" | "ios";
+export type DesktopNativePlatform = NativePlatform | "electron";
 
 export interface EmulatorDevice {
   id: string;
@@ -15,7 +16,7 @@ export interface PrerequisiteIssue {
 }
 
 export interface PrerequisiteCheck {
-  platform: NativePlatform;
+  platform: DesktopNativePlatform;
   available: boolean;
   canProceed?: boolean;
   issues: PrerequisiteIssue[];

--- a/packages/cli/src/orchestrator/index.ts
+++ b/packages/cli/src/orchestrator/index.ts
@@ -26,6 +26,26 @@ import {
   upsertNativeLaunchMemory,
 } from "../emulator/native-launch.js";
 import { buildActionPrompt, validateScenarioActions } from "../emulator/native-actions.js";
+import { 
+  resolveDesktopLaunchTarget, 
+  describeDesktopLaunchTarget, 
+  persistDesktopLaunchTarget, 
+  upsertDesktopLaunchMemory, 
+  parseDesktopLaunchMemory 
+} from "../desktop/desktop-launch.js";
+import { 
+  launchElectronApp, 
+  closeElectronApp, 
+  captureElectronScreenshot, 
+  getElectronUIStructure,
+  clickElectronElement,
+  fillElectronElement,
+  pressElectronKey,
+  scrollElectron,
+  type ElectronSession 
+} from "../desktop/electron-app.js";
+import { buildDesktopActionPrompt, validateDesktopScenarioActions } from "../desktop/desktop-actions.js";
+import type { DesktopPlatform, ResolvedDesktopLaunchTarget } from "../desktop/types.js";
 import { getAndroidToolEnv } from "../emulator/android-sdk.js";
 import type {
   NativeAutomationProfile,
@@ -41,6 +61,7 @@ import {
   describeHybridWebview,
   fillAppiumElement,
   getAppiumContexts,
+  getAppiumPageSource,
   navigateAppiumTo,
   pressAppiumKey,
   scrollAppiumBy,
@@ -686,6 +707,418 @@ export async function runTestSession(
   }
 }
 
+// ─── Desktop app test session ────────────────────────────
+export async function runDesktopTestSession(
+  projectPath: string,
+  options: {
+    url?: string;
+    scope?: string;
+    persona?: TestPersona;
+    desktopPlatform: DesktopPlatform;
+  },
+  callbacks: OrchestratorCallbacks,
+): Promise<TestReport> {
+  const startTime = Date.now();
+  const settings = await loadConfig(projectPath);
+  const provider = getProvider(settings.provider);
+  const persona = options.persona ?? "standard";
+  const personaProfile = getPersonaProfile(persona);
+  const findings: TestFinding[] = [];
+  const execution: TestExecutionSummary = {
+    browserSessions: 0,
+    navigations: 0,
+    screenshots: 0,
+    scenariosPlanned: 0,
+    scenariosExecuted: 0,
+    evidenceMet: false,
+  };
+
+  const runId = generateId();
+  const memory = await loadMemory(projectPath);
+  const memoryUrl = parseMemoryUrl(memory);
+  const { url: resolvedUrl, ignoredSources } = await resolveTestUrl(
+    projectPath,
+    options.url,
+    settings.project.url,
+    memoryUrl,
+  );
+
+  const context: TestContext = {
+    projectPath,
+    url: resolvedUrl,
+    scope: options.scope,
+    persona,
+    deviceProfile: "desktop",
+    baselineDir: getBaselineDir(projectPath),
+    reportDir: join(getReportDir(projectPath), runId),
+  };
+
+  await mkdir(context.reportDir, { recursive: true });
+
+  const desktopStepNames = [
+    "Scan project structure",
+    "Load project context",
+    "Resolve desktop launch target",
+    "Launch desktop app",
+    "Capture screenshots",
+    "Reconnaissance & test planning",
+    "Execute test scenarios",
+    "Generate report",
+  ];
+  const steps: TestStep[] = desktopStepNames.map((name) => ({ name, status: "pending" }));
+  callbacks.onStepUpdate(steps);
+
+  let debugLog = `GetWired Debug Log (Desktop ${options.desktopPlatform})\nRun: ${runId}\nTimestamp: ${new Date().toISOString()}\nProvider: ${settings.provider}\nPersona: ${persona}\nPlatform: ${options.desktopPlatform}\nURL: ${resolvedUrl ?? "(none)"}\n${"─".repeat(60)}\n\n`;
+  let desktopSession: ElectronSession | null = null;
+
+  const out = (text: string) => {
+    debugLog += text;
+    callbacks.onProviderOutput?.(text);
+  };
+
+  const saveDebugLog = async (error?: string) => {
+    if (error) debugLog += `\n\n${"─".repeat(60)}\nERROR: ${error}\n`;
+    debugLog += `\n${"─".repeat(60)}\nStep Summary\n${"─".repeat(60)}\n`;
+    for (const step of steps) {
+      const icon = step.status === "passed" ? "✔" : step.status === "failed" ? "✘" : "?";
+      debugLog += `  ${icon} [${step.status}] ${step.name}\n`;
+    }
+    debugLog += `\nCompleted: ${new Date().toISOString()}\nDuration: ${Date.now() - startTime}ms\n`;
+    await writeFile(join(context.reportDir, "debug.log"), debugLog).catch(() => {});
+  };
+
+  for (const ignoredSource of ignoredSources) {
+    const warning = `Ignoring ${ignoredSource} because GetWired only tests local apps on localhost or loopback addresses.`;
+    out(`> ${warning}\n`);
+  }
+
+  const recordFindings = (newFindings: TestFinding[]) => {
+    for (const finding of newFindings) {
+      findings.push(finding);
+      callbacks.onFinding(finding);
+    }
+  };
+
+  async function streamAnalyze(
+    ctx: TestContext,
+    messages: { role: "user" | "assistant" | "system"; content: string }[],
+  ): Promise<string> {
+    let full = "";
+    for await (const chunk of provider.stream(ctx, messages)) {
+      if (chunk.type === "text" && chunk.content) {
+        out(chunk.content);
+        full += chunk.content;
+      } else if (chunk.type === "tool_call" && chunk.toolCall) {
+        const activity = toolCallActivity(chunk.toolCall.name, persona);
+        out(`> ${activity}\n`);
+      }
+    }
+    out("\n");
+    return full;
+  }
+
+  try {
+    const platformLabel = "⚡ Electron";
+
+    // ── Step 1: Scan project ─────────────────────────
+    callbacks.onPhaseChange("scanning", "Scanning project structure...");
+    await updateStep(steps, 0, "running", callbacks);
+    const projectInfo = await scanProject(projectPath, context);
+    await updateStep(steps, 0, "passed", callbacks, Date.now() - startTime);
+
+    // ── Step 2: Load notes & memory ──────────────────
+    callbacks.onPhaseChange("scanning", "Loading project context...");
+    await updateStep(steps, 1, "running", callbacks);
+    const notes = await loadProjectNotes(projectPath);
+    if (memory) out(`> Loaded memory from previous test sessions\n`);
+    await updateStep(steps, 1, "passed", callbacks);
+
+    // ── Step 3: Resolve launch strategy ──────────────
+    callbacks.onPhaseChange("planning", `Inspecting project for ${platformLabel} launch...`);
+    await updateStep(steps, 2, "running", callbacks, undefined, `Inspecting project for ${platformLabel} launch`);
+    out(`> Resolving ${platformLabel} app target from memory, config, or project files...\n`);
+
+    const desktopLaunchTarget = await resolveDesktopLaunchTarget(options.desktopPlatform, projectPath, settings, memory);
+    out(`  Using ${describeDesktopLaunchTarget(desktopLaunchTarget)} [${desktopLaunchTarget.source}]\n`);
+
+    let resolvedSettings = persistDesktopLaunchTarget(settings, desktopLaunchTarget);
+    await saveConfig(projectPath, resolvedSettings).catch(() => {});
+
+    const resolvedMemory = upsertDesktopLaunchMemory(memory, desktopLaunchTarget);
+    await saveMemory(projectPath, resolvedMemory).catch(() => {});
+
+    await updateStep(steps, 2, "passed", callbacks, undefined, describeDesktopLaunchTarget(desktopLaunchTarget));
+
+    // ── Step 4: Launch app ──────────────────────────
+    callbacks.onPhaseChange("testing", `Launching ${platformLabel} app...`);
+    await updateStep(steps, 3, "running", callbacks, undefined, `Starting ${platformLabel}`);
+    out(`> Starting ${platformLabel}...\n`);
+
+    const screenshotDir = join(context.reportDir, "screenshots");
+    await mkdir(screenshotDir, { recursive: true });
+
+    try {
+      desktopSession = await launchElectronApp(desktopLaunchTarget as import("../desktop/types.js").ResolvedElectronLaunchTarget);
+      out(`  App launched successfully\n`);
+      await new Promise((r) => setTimeout(r, 2000));
+      await updateStep(steps, 3, "passed", callbacks);
+    } catch (error) {
+      out(`  ! Failed to launch app: ${String(error)}\n`);
+      await updateStep(steps, 3, "failed", callbacks, undefined, String(error));
+      throw error;
+    }
+
+    // ── Step 5: Capture screenshots ──────────────────
+    callbacks.onPhaseChange("capturing-current", `Capturing screenshots on ${platformLabel}...`);
+    await updateStep(steps, 4, "running", callbacks);
+    out(`> Taking screenshots on ${platformLabel}...\n`);
+
+    const screenshotPath = join(screenshotDir, `desktop-${options.desktopPlatform}-initial.png`);
+    try {
+      const screenshotBuffer = await captureElectronScreenshot(desktopSession!);
+      await writeFile(screenshotPath, screenshotBuffer);
+      execution.screenshots++;
+      out(`  📸 Saved: ${toProjectRelativePath(projectPath, screenshotPath)}\n`);
+      await updateStep(steps, 4, "passed", callbacks, undefined, "Screenshot captured");
+    } catch (err) {
+      out(`  ! Screenshot failed: ${String(err).slice(0, 100)}\n`);
+      await updateStep(steps, 4, "failed", callbacks, undefined, "Screenshot capture failed");
+    }
+
+    // ── Step 6: Reconnaissance — get UI structure ────
+    callbacks.onPhaseChange("planning", personaProfile.phaseMessages.planning);
+    await updateStep(steps, 5, "running", callbacks);
+    out(`> ${settings.provider}: ${personaProfile.outputMessages.planning}\n\n`);
+
+    let uiStructure = "";
+    try {
+      uiStructure = await getElectronUIStructure(desktopSession!);
+      out(`  Using desktop UI structure (Playwright accessibility tree)\n`);
+    } catch (error) {
+      out(`  ! Failed to get UI structure: ${String(error)}\n`);
+    }
+
+    if (!uiStructure || uiStructure.length < 100) {
+      const blockerMessage = `Desktop ${platformLabel} UI structure is not actionable: Empty or minimal UI dump`;
+      out(`  ! ${blockerMessage}\n`);
+      callbacks.onLog(blockerMessage);
+      findings.push({
+        id: `desktop-ui-${generateId()}`,
+        severity: "high",
+        category: "functional",
+        title: `${platformLabel} accessibility tree is not actionable`,
+        description: `Empty or minimal UI structure. GetWired stopped before generating interaction scenarios because taps and assertions would be unreliable.`,
+        device: "desktop",
+        steps: [
+          `Launch the app in ${platformLabel}`,
+          "Capture the initial screenshot",
+          "Read the accessibility tree / UI structure",
+        ],
+      });
+      await updateStep(steps, 5, "failed", callbacks, undefined, "UI structure not actionable");
+      await updateStep(steps, 6, "failed", callbacks, undefined, "Skipped because the UI dump was not actionable");
+    } else {
+      const testPlan = await streamAnalyze(context, [
+        { role: "system", content: buildSystemPrompt(persona, memory) },
+        {
+          role: "user",
+          content: buildDesktopReconPrompt(context, projectInfo, notes, uiStructure, desktopLaunchTarget),
+        },
+      ]);
+
+      callbacks.onLog(`Test plan generated with ${countPlanSteps(testPlan)} items`);
+      await updateStep(steps, 5, "passed", callbacks);
+
+      // ── Step 7: Execute test scenarios ────────────────
+      callbacks.onPhaseChange("testing", personaProfile.phaseMessages.scenarios);
+      await updateStep(steps, 6, "running", callbacks, undefined, `Using ${platformLabel}`);
+      out(`\n> ${settings.provider}: ${personaProfile.outputMessages.scenarios}\n\n`);
+
+      const scenarioPlanResult = await streamAnalyze(context, [
+        { role: "system", content: buildSystemPrompt(persona, memory) },
+        {
+          role: "user",
+          content: buildDesktopScenariosPrompt(context, testPlan, uiStructure, desktopLaunchTarget),
+        },
+      ]);
+
+      const rawScenarios = parseScenarios(scenarioPlanResult);
+      let plannedScenarios = validateDesktopScenarioActions(rawScenarios, options.desktopPlatform);
+      
+      if (rawScenarios.length > 0 && plannedScenarios.length < rawScenarios.length) {
+        const dropped = rawScenarios.length - plannedScenarios.length;
+        out(`  Filtered ${dropped} scenario${dropped === 1 ? "" : "s"} with invalid action types\n`);
+      }
+
+      execution.scenariosPlanned += plannedScenarios.length;
+
+      if (plannedScenarios.length === 0) {
+        out(`  ! Provider returned no executable desktop scenarios\n`);
+      }
+
+      if (plannedScenarios.length > 0) {
+        out(`  Executing ${plannedScenarios.length} desktop scenario${plannedScenarios.length === 1 ? "" : "s"}...\n`);
+        
+        for (const scenario of plannedScenarios) {
+          out(`\n  ▶ ${scenario.name}\n`);
+          execution.scenariosExecuted++;
+
+          for (const action of scenario.actions) {
+            try {
+              if (action.type === "tap" || action.type === "click") {
+                await clickElectronElement(desktopSession!, action.selector || "");
+                out(`    ✓ ${action.description || `Tap ${action.selector}`}\n`);
+              } else if (action.type === "fill" && action.value) {
+                await fillElectronElement(desktopSession!, action.selector || "", action.value);
+                out(`    ✓ ${action.description || `Fill ${action.selector}`}\n`);
+              } else if (action.type === "keyboard" && action.key) {
+                await pressElectronKey(desktopSession!, action.key);
+                out(`    ✓ ${action.description || `Press ${action.key}`}\n`);
+              } else if (action.type === "screenshot") {
+                const scenarioScreenshotPath = join(screenshotDir, `scenario-${execution.screenshots}.png`);
+      const screenshotBuffer = await captureElectronScreenshot(desktopSession!);
+                await writeFile(scenarioScreenshotPath, screenshotBuffer);
+                execution.screenshots++;
+                out(`    ✓ ${action.description || "Screenshot"} 📸\n`);
+              }
+              await new Promise((r) => setTimeout(r, 500));
+            } catch (error) {
+              out(`    ✗ ${action.description || action.type}: ${String(error).slice(0, 100)}\n`);
+            }
+          }
+        }
+      }
+
+      await updateStep(steps, 6, "passed", callbacks);
+    }
+
+    // ── Step 8: Generate report ──────────────────────
+    callbacks.onPhaseChange("reporting", "Generating test report...");
+    await updateStep(steps, 7, "running", callbacks);
+
+    const report: TestReport = {
+      id: runId,
+      timestamp: new Date().toISOString(),
+      provider: settings.provider,
+      context,
+      findings,
+      execution,
+      steps: steps.map(s => ({ name: s.name, status: s.status, duration: s.duration, details: s.details })),
+      summary: {
+        totalTests: execution.scenariosPlanned,
+        passed: execution.scenariosExecuted,
+        failed: findings.filter(f => f.severity === "high" || f.severity === "critical").length,
+        warnings: findings.filter(f => f.severity === "medium" || f.severity === "low").length,
+        duration: Date.now() - startTime,
+      },
+      notes: [],
+    };
+
+    await writeFile(join(context.reportDir, "report.json"), JSON.stringify(report, null, 2));
+    out(`> Report saved: ${toProjectRelativePath(projectPath, join(context.reportDir, "report.json"))}\n`);
+
+    await saveDebugLog();
+    await updateStep(steps, 7, "passed", callbacks);
+
+    callbacks.onPhaseChange("done", "Testing complete!");
+    return report;
+  } catch (err) {
+    await saveDebugLog(String(err));
+    out(`\n! Error: ${String(err)}\n`);
+    out(`> Debug log saved: ${runId}/debug.log\n`);
+    callbacks.onPhaseChange("error", `Error: ${err}`);
+    throw err;
+  } finally {
+    if (desktopSession) {
+      try {
+        await closeElectronApp(desktopSession);
+      } catch (error) {
+        out(`  ! Failed to close app: ${String(error)}\n`);
+      }
+    }
+  }
+}
+
+function buildDesktopReconPrompt(
+  context: TestContext,
+  projectInfo: string,
+  notes: string,
+  uiStructure: string,
+  launchTarget: ResolvedDesktopLaunchTarget,
+): string {
+  return `You are testing a desktop application.
+
+## Project Context
+${projectInfo}
+
+## Notes
+${notes || "No project notes available."}
+
+## Launch Target
+Platform: ${launchTarget.platform}
+Source: ${launchTarget.source}
+${launchTarget.launchCommand ? `Launch Command: ${launchTarget.launchCommand}` : ""}
+
+## Current UI Structure
+\`\`\`
+${uiStructure.slice(0, 8000)}
+\`\`\`
+
+## Task
+Analyze the desktop application UI and create a test plan covering:
+1. Core functionality verification
+2. Navigation flows
+3. Input validation
+4. Error handling
+5. Accessibility checks
+
+Provide a numbered list of test items to validate the application.`;
+}
+
+function buildDesktopScenariosPrompt(
+  context: TestContext,
+  testPlan: string,
+  uiStructure: string,
+  launchTarget: ResolvedDesktopLaunchTarget,
+): string {
+  const actionPrompt = buildDesktopActionPrompt(launchTarget.platform);
+  
+  return `You are testing a desktop application on ${launchTarget.platform}.
+
+## Test Plan
+${testPlan}
+
+## Current UI Structure
+\`\`\`
+${uiStructure.slice(0, 8000)}
+\`\`\`
+
+## Available Actions
+${actionPrompt}
+
+## Task
+Generate test scenarios as a JSON array. Each scenario should have:
+- name: string
+- category: "happy-path" | "edge-case" | "abuse" | "boundary" | "error-recovery"
+- actions: array of action objects with type, selector, value (if needed), and description
+
+Example:
+\`\`\`json
+[
+  {
+    "name": "Test login flow",
+    "category": "happy-path",
+    "actions": [
+      { "type": "fill", "selector": "#username", "value": "test@example.com", "description": "Enter username" },
+      { "type": "tap", "selector": "#login-button", "description": "Click login" }
+    ]
+  }
+]
+\`\`\`
+
+Return ONLY the JSON array, no other text.`;
+}
+
 // ─── Native emulator test session ────────────────────────────
 export async function runNativeTestSession(
   projectPath: string,
@@ -797,7 +1230,7 @@ export async function runNativeTestSession(
   }
 
   try {
-    const platformLabel = options.nativePlatform === "android" ? "🤖 Android Emulator" : "🍎 iOS Simulator";
+    const platformLabel = options.nativePlatform === "android" ? "Android" : "iOS";
 
     // ── Step 1: Scan project ─────────────────────────
     callbacks.onPhaseChange("scanning", "Scanning project structure...");
@@ -1052,7 +1485,7 @@ export async function runNativeTestSession(
 
     const nativeUiDiagnostics = automationMode === "hybrid"
       ? analyzeHybridUiStructure(uiStructure, nativeLaunchTarget.automation, hybridContextError, hybridContexts, hybridWebviewContext)
-      : analyzeNativeUiStructure(options.nativePlatform, uiStructure, nativeLaunchTarget);
+      : analyzeNativeUiStructure(options.nativePlatform as "android" | "ios", uiStructure, nativeLaunchTarget);
     if (automationMode === "hybrid" && nativeUiDiagnostics.actionable) {
       const cacheIdentity = buildHybridScenarioCacheKey(nativeLaunchTarget, uiStructure);
       hybridCacheKey = cacheIdentity.key;
@@ -1184,7 +1617,7 @@ export async function runNativeTestSession(
             {
               key: hybridCacheKey,
               createdAt: new Date().toISOString(),
-              platform: options.nativePlatform,
+              platform: options.nativePlatform as "android" | "ios",
               framework: nativeLaunchTarget.automation.framework,
               viewUrl: hybridCacheViewUrl,
               title: hybridCacheTitle,


### PR DESCRIPTION
## Summary

Adds Electron desktop application testing support to GetWired, enabling AI-driven testing of Electron apps using **Playwright's Electron API** — following the same architecture and patterns used for web and mobile testing.

## What's New

### New Module: `packages/cli/src/desktop/`

| File | Purpose |
|------|---------|  
| `types.ts` | `DesktopPlatform`, `ResolvedElectronLaunchTarget` types |
| `electron-app.ts` | Electron app lifecycle via Playwright: launch, screenshot, UI structure, interactions, close |
| `detect.ts` | Prerequisite checks (Playwright installed?) |
| `ensure-dependencies.ts` | Auto-install Playwright for Electron testing |
| `desktop-launch.ts` | Resolve Electron app launch targets from package.json, config, or memory |
| `desktop-actions.ts` | Action registry and AI prompt generation for desktop testing |

### Modified Files

| File | Change |
|------|--------|
| `emulator/types.ts` | Extended `NativePlatform` with `"electron"` |
| `emulator/appium.ts` | Minor cleanup of Electron references (Electron now uses Playwright, not Appium) |
| `orchestrator/index.ts` | Added `runDesktopTestSession()` — full test orchestration for Electron |
| `components/RunCommand.tsx` | 3-way routing: desktop → `runDesktopTestSession`, mobile → `runNativeTestSession`, web → `runTestSession` |
| `components/App.tsx` | Electron in platform selector, prerequisite checks, auto-install flow |
| `cli.tsx` | `--platform electron` flag support |
| `config/settings.ts` | Desktop config section (`native.electron`) |

## How It Works

### CLI
```bash
getwired test --platform electron
```

### Dashboard
Native App Test → Select **⚡ Electron** → prerequisite check → launch & test

### Architecture
- Uses **Playwright's Electron API** (`_electron.launch()`) for automation
- Finds the Electron binary in the target project's `node_modules`
- Handles window lifecycle gracefully (splash screens, window transitions)
- Extracts full DOM structure with CSS selectors and XPath for AI planning
- Takes screenshots without screen takeover
- Runs test scenarios using standard web selectors (CSS, XPath, text)

### Test Flow
1. Scan project structure
2. Load project context
3. Resolve Electron launch target (from package.json `main` field, config, or memory)
4. Launch Electron app via Playwright
5. Capture initial screenshots
6. AI reconnaissance & test planning (analyzes UI structure, generates test plan)
7. Execute test scenarios (click, fill, keyboard, screenshots, assertions)
8. Generate report

## Testing

- ✅ TypeScript compilation: zero errors
- ✅ End-to-end tested on a real Electron app (Orthobot)
- ✅ 19 test scenarios executed successfully including: login flows, input validation, XSS, SQL injection, language toggle, accessibility, and stress tests
- ✅ Existing web and mobile testing unaffected

## Key Design Decisions

1. **Playwright over Appium** — Initially tried Appium Mac2 driver, but it takes over the screen and doesn't support Electron webview contexts. Playwright Electron API is the right tool: background execution, direct Chromium access, native web selectors.

2. **Window lifecycle handling** — Electron apps often create splash/loading windows that close before the main window appears. Added `getActiveWindow()` and `ensureActivePage()` helpers that automatically find the current alive window.

3. **Electron-only scope** — Originally planned macOS/Windows native app support too, but scoped down to Electron as the immediate priority. Architecture supports extending later.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author