### PR TITLE
Add MCP server integration for AI coding agent support

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "getwired": {
+      "command": "getwired",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Run GetWired from your project folder directly. For web apps, it tests local app
 | `getwired init` | Initialize GetWired and configure your AI provider |
 | `getwired test` | Run AI-driven chaotic testing against your local dev server |
 | `getwired report` | View test reports |
+| `getwired mcp` | Start MCP server for AI coding agent integration |
 
 ### Test Flags
 
@@ -82,6 +83,103 @@ npx getwired init --provider auggie
 | **Web Apps** | Any web app on localhost — Next.js, React, Vue, Svelte, plain HTML, and more |
 | **Native Android** | Android apps running in an emulator via ADB |
 | **Native iOS** | iOS apps running in the Simulator via AXe |
+
+## MCP Integration
+
+Use GetWired as an MCP server so your AI coding agent can run tests directly. Works with Claude Code, Cursor, Windsurf, Codex, and any MCP-compatible tool.
+
+```bash
+getwired mcp
+```
+
+### Claude Code
+
+Add to `~/.claude/settings.json` (global) or `.claude/settings.json` (project):
+
+```json
+{
+  "mcpServers": {
+    "getwired": {
+      "command": "getwired",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Restart Claude Code for changes to take effect.
+
+### OpenAI Codex
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.getwired]
+command = "getwired"
+args = ["mcp"]
+```
+
+Or via the CLI:
+
+```bash
+codex mcp add getwired -- getwired mcp
+```
+
+### Augment Code (Auggie)
+
+Open Augment settings, go to MCP servers, and add this JSON:
+
+```json
+{
+  "mcpServers": {
+    "getwired": {
+      "command": "getwired",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
+
+```json
+{
+  "mcpServers": {
+    "getwired": {
+      "command": "getwired",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "getwired": {
+      "command": "getwired",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Available MCP Tools
+
+| Tool | Description |
+| --- | --- |
+| `getwired_check_status` | Check if GetWired is initialized in a project |
+| `getwired_init` | Initialize GetWired configuration |
+| `getwired_run_test` | Run a full AI-powered test session |
+| `getwired_list_reports` | List past test reports |
+| `getwired_get_report` | Get a full report by ID |
+| `getwired_get_findings` | Get findings filtered by severity or category |
 
 ## How It Works
 

--- a/apps/web/app/docs/commands/page.tsx
+++ b/apps/web/app/docs/commands/page.tsx
@@ -39,6 +39,12 @@ const commands = [
     example: "$ getwired report --id latest",
   },
   {
+    name: "getwired mcp",
+    desc: "Start an MCP server for AI coding agent integration. Lets Claude Code, Codex, Cursor, Windsurf, and other MCP-compatible agents run tests, read reports, and manage configuration directly.",
+    flags: [],
+    example: "$ getwired mcp",
+  },
+  {
     name: "getwired dashboard",
     desc: "Open the interactive TUI dashboard. This is the default command when running getwired with no arguments. Gives you access to test runs, reports, notes, and settings.",
     flags: [],

--- a/apps/web/app/docs/configuration/page.tsx
+++ b/apps/web/app/docs/configuration/page.tsx
@@ -72,10 +72,10 @@ export default function Configuration() {
 
       <div className="mt-12 flex justify-between">
         <Link
-          href="/docs/reports"
+          href="/docs/mcp"
           className="rounded border border-emerald-500/20 px-4 py-2 font-mono text-xs text-emerald-500/60 transition hover:border-emerald-400/50 hover:bg-emerald-400 hover:text-black"
         >
-          &larr; Reports
+          &larr; MCP
         </Link>
         <Link
           href="/docs/authentication"

--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -10,6 +11,7 @@ const NAV_ITEMS = [
   { href: "/docs/providers", label: "PROVIDERS" },
   { href: "/docs/test-modes", label: "TEST-MODES" },
   { href: "/docs/reports", label: "REPORTS" },
+  { href: "/docs/mcp", label: "MCP" },
   { href: "/docs/configuration", label: "CONFIGURATION" },
   { href: "/docs/authentication", label: "AUTHENTICATION" },
   { href: "/docs/faq", label: "FAQ" },
@@ -17,11 +19,14 @@ const NAV_ITEMS = [
 
 export default function DocsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const activeLabel = NAV_ITEMS.find((item) => item.href === pathname)?.label ?? "DOCS";
 
   return (
     <div className="flex min-h-screen bg-black">
-      {/* Sidebar */}
-      <aside className="sticky top-0 h-screen w-64 shrink-0 border-r border-emerald-500/20 bg-black/95 p-6 overflow-y-auto">
+      {/* Desktop sidebar */}
+      <aside className="sticky top-0 hidden h-screen w-64 shrink-0 border-r border-emerald-500/20 bg-black/95 p-6 overflow-y-auto md:block">
         <Link href="/" className="block mb-8">
           <span className="font-mono text-sm font-bold text-emerald-400 tracking-widest">
             GETWIRED
@@ -58,6 +63,70 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
         </div>
       </aside>
 
+      {/* Mobile header + collapsible menu */}
+      <div className="fixed inset-x-0 top-0 z-50 md:hidden">
+        <div className="flex items-center justify-between border-b border-emerald-500/20 bg-black/95 px-4 py-3 backdrop-blur">
+          <Link href="/" className="flex items-baseline gap-2">
+            <span className="font-mono text-sm font-bold text-emerald-400 tracking-widest">
+              GETWIRED
+            </span>
+            <span className="font-mono text-[10px] text-emerald-600">DOCS</span>
+          </Link>
+          <button
+            onClick={() => setMenuOpen((o) => !o)}
+            className="flex items-center gap-2 rounded border border-emerald-500/20 px-3 py-1.5 font-mono text-xs text-emerald-500 transition hover:border-emerald-400/50 hover:text-emerald-400"
+            aria-expanded={menuOpen}
+            aria-controls="mobile-nav"
+          >
+            [{activeLabel}]
+            <span
+              className="inline-block transition-transform duration-200"
+              style={{ transform: menuOpen ? "rotate(180deg)" : undefined }}
+            >
+              &#9662;
+            </span>
+          </button>
+        </div>
+
+        {menuOpen && (
+          <nav
+            id="mobile-nav"
+            className="border-b border-emerald-500/20 bg-black/95 px-4 pb-4 pt-2 backdrop-blur"
+            aria-label="Documentation"
+          >
+            <div className="flex flex-col gap-1">
+              {NAV_ITEMS.map((item) => {
+                const isActive = pathname === item.href;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setMenuOpen(false)}
+                    className={`rounded px-3 py-2 font-mono text-xs transition ${
+                      isActive
+                        ? "bg-emerald-500/10 text-emerald-400 border border-emerald-500/30"
+                        : "text-emerald-500 hover:text-emerald-400 hover:bg-emerald-500/5 border border-transparent"
+                    }`}
+                  >
+                    [{item.label}]
+                  </Link>
+                );
+              })}
+            </div>
+            <div className="mt-4 pt-4 border-t border-emerald-500/10">
+              <a
+                href="https://github.com/JaySym-ai/getwired"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-[10px] text-emerald-600 hover:text-emerald-400 transition"
+              >
+                GitHub &rarr;
+              </a>
+            </div>
+          </nav>
+        )}
+      </div>
+
       {/* Main content */}
       <main id="main-content" className="flex-1 overflow-y-auto">
         {/* Top banner */}
@@ -93,7 +162,10 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
           </div>
         </div>
 
-        <div className="max-w-4xl mx-auto px-8 py-12">
+        {/* Spacer for fixed mobile header */}
+        <div className="h-12 md:hidden" />
+
+        <div className="max-w-4xl mx-auto px-4 py-8 md:px-8 md:py-12">
           {children}
         </div>
 

--- a/apps/web/app/docs/mcp/page.tsx
+++ b/apps/web/app/docs/mcp/page.tsx
@@ -1,0 +1,309 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "MCP Integration",
+  description:
+    "Connect GetWired to your AI coding agent via MCP. Step-by-step setup for Claude Code, Codex, Augment Code, Cursor, and Windsurf.",
+  alternates: { canonical: "https://getwired.dev/docs/mcp" },
+};
+
+const agents = [
+  {
+    name: "Claude Code",
+    id: "claude-code",
+    description:
+      "Anthropic's Claude Code supports MCP servers via a JSON settings file. You can configure it globally or per-project.",
+    steps: [
+      "Install GetWired globally: npm install -g getwired",
+      "Open your settings file at ~/.claude/settings.json (global) or .claude/settings.json (project-scoped)",
+      "Add the GetWired MCP server configuration (see below)",
+      "Restart Claude Code for changes to take effect",
+    ],
+    configFile: "~/.claude/settings.json",
+    configFormat: "json" as const,
+    config: `{
+  "mcpServers": {
+    "getwired": {
+      "command": "getwired",
+      "args": ["mcp"]
+    }
+  }
+}`,
+  },
+  {
+    name: "OpenAI Codex",
+    id: "codex",
+    description:
+      "OpenAI Codex CLI uses a TOML configuration file for MCP servers. You can also add servers via the CLI.",
+    steps: [
+      "Install GetWired globally: npm install -g getwired",
+      "Open ~/.codex/config.toml (create it if it doesn't exist)",
+      "Add the GetWired MCP server configuration (see below)",
+      "Restart Codex for changes to take effect",
+    ],
+    configFile: "~/.codex/config.toml",
+    configFormat: "toml" as const,
+    config: `[mcp_servers.getwired]
+command = "getwired"
+args = ["mcp"]`,
+    altMethod: "Or add it via the CLI: codex mcp add getwired -- getwired mcp",
+  },
+  {
+    name: "Augment Code (Auggie)",
+    id: "auggie",
+    description:
+      "Augment Code supports MCP through its settings panel. You can import a JSON configuration directly.",
+    steps: [
+      "Install GetWired globally: npm install -g getwired",
+      "Open Augment Code settings",
+      "Navigate to MCP servers section",
+      "Click \"Import\" or \"Add Server\" and paste the JSON configuration below",
+      "Save and restart if prompted",
+    ],
+    configFile: "Augment Settings > MCP Servers",
+    configFormat: "json" as const,
+    config: `{
+  "mcpServers": {
+    "getwired": {
+      "command": "getwired",
+      "args": ["mcp"]
+    }
+  }
+}`,
+  },
+  {
+    name: "Cursor",
+    id: "cursor",
+    description:
+      "Cursor uses a JSON file for MCP configuration. Supports both global and project-scoped settings.",
+    steps: [
+      "Install GetWired globally: npm install -g getwired",
+      "Open ~/.cursor/mcp.json (global) or .cursor/mcp.json (in your project root)",
+      "Add the GetWired MCP server configuration (see below)",
+      "Restart Cursor for changes to take effect",
+    ],
+    configFile: "~/.cursor/mcp.json",
+    configFormat: "json" as const,
+    config: `{
+  "mcpServers": {
+    "getwired": {
+      "command": "getwired",
+      "args": ["mcp"]
+    }
+  }
+}`,
+  },
+  {
+    name: "Windsurf",
+    id: "windsurf",
+    description:
+      "Windsurf stores MCP configuration in a JSON file under your Codeium directory. You can also configure it through the UI.",
+    steps: [
+      "Install GetWired globally: npm install -g getwired",
+      "Open ~/.codeium/windsurf/mcp_config.json",
+      "Add the GetWired MCP server configuration (see below)",
+      "Restart Windsurf or press Cmd/Ctrl+Shift+P and reload MCP servers",
+    ],
+    configFile: "~/.codeium/windsurf/mcp_config.json",
+    configFormat: "json" as const,
+    config: `{
+  "mcpServers": {
+    "getwired": {
+      "command": "getwired",
+      "args": ["mcp"]
+    }
+  }
+}`,
+  },
+];
+
+const tools = [
+  {
+    name: "getwired_check_status",
+    description: "Check if GetWired is initialized and configured in a project. Call this first to understand the current state.",
+  },
+  {
+    name: "getwired_init",
+    description: "Initialize GetWired configuration in a project. Creates .getwired/config.json with sensible defaults.",
+  },
+  {
+    name: "getwired_run_test",
+    description: "Run a full AI-powered test session on a web, native, or desktop app. Accepts URL, scope, persona, platform, and regression options. Takes 2-5 minutes.",
+  },
+  {
+    name: "getwired_list_reports",
+    description: "List available test reports with summaries including pass/fail counts, timestamps, and finding counts.",
+  },
+  {
+    name: "getwired_get_report",
+    description: "Get a complete test report by ID with all findings, steps, and execution details.",
+  },
+  {
+    name: "getwired_get_findings",
+    description: "Get findings filtered by severity (critical, high, medium, low, info) or category (ui-regression, functional, accessibility, etc.).",
+  },
+];
+
+export default function McpDocs() {
+  return (
+    <div>
+      <h1 className="font-mono text-2xl font-bold text-emerald-400 tracking-wider">
+        [MCP]
+      </h1>
+      <p className="mt-2 font-mono text-sm text-emerald-500/50">
+        Connect GetWired to your AI coding agent.
+      </p>
+
+      <p className="mt-6 font-mono text-xs text-emerald-500/60 leading-relaxed">
+        GetWired includes a built-in MCP (Model Context Protocol) server that lets any
+        compatible AI coding agent run tests, read reports, and manage your testing
+        configuration. Your agent gets 6 tools to work with &mdash; from running a full
+        test session to filtering findings by severity.
+      </p>
+
+      {/* Quick start */}
+      <div className="mt-8 rounded-lg border border-emerald-500/15 bg-black/40 p-6">
+        <h2 className="font-mono text-sm font-bold text-emerald-300">Quick Start</h2>
+        <div className="mt-3 flex flex-col gap-2">
+          <div className="flex gap-3 font-mono text-xs">
+            <span className="text-emerald-400 shrink-0">1.</span>
+            <span className="text-emerald-500/60">Install GetWired globally</span>
+          </div>
+          <div
+            className="rounded border border-emerald-500/20 bg-black/80 px-4 py-3 font-mono text-sm text-green-400"
+            style={{ boxShadow: "0 0 20px rgba(16, 185, 129, 0.06)" }}
+          >
+            $ npm install -g getwired
+          </div>
+          <div className="flex gap-3 font-mono text-xs mt-2">
+            <span className="text-emerald-400 shrink-0">2.</span>
+            <span className="text-emerald-500/60">
+              Add the config for your agent (see below)
+            </span>
+          </div>
+          <div className="flex gap-3 font-mono text-xs mt-2">
+            <span className="text-emerald-400 shrink-0">3.</span>
+            <span className="text-emerald-500/60">
+              Restart your agent &mdash; GetWired tools will appear automatically
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Agent setup guides */}
+      <h2 className="mt-12 font-mono text-lg font-bold text-emerald-400 tracking-wider">
+        Setup by Agent
+      </h2>
+
+      <div className="mt-6 flex flex-col gap-8">
+        {agents.map((agent) => (
+          <div
+            key={agent.id}
+            id={agent.id}
+            className="rounded-lg border border-emerald-500/15 bg-black/40 p-6"
+          >
+            <h3 className="font-mono text-sm font-bold text-emerald-300">
+              {agent.name}
+            </h3>
+            <p className="mt-2 font-mono text-xs text-emerald-500/60 leading-relaxed">
+              {agent.description}
+            </p>
+
+            <div className="mt-4">
+              <p className="font-mono text-[10px] uppercase tracking-widest text-emerald-500/30 mb-2">
+                Steps
+              </p>
+              <div className="flex flex-col gap-1">
+                {agent.steps.map((step, i) => (
+                  <div key={i} className="flex gap-3 font-mono text-xs">
+                    <span className="text-emerald-400 shrink-0">{i + 1}.</span>
+                    <span className="text-emerald-500/60">{step}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-4">
+              <p className="font-mono text-[10px] uppercase tracking-widest text-emerald-500/30 mb-2">
+                {agent.configFile}
+              </p>
+              <div
+                className="rounded border border-emerald-500/20 bg-black/80 px-4 py-3 font-mono text-sm text-green-400 whitespace-pre overflow-x-auto"
+                style={{ boxShadow: "0 0 20px rgba(16, 185, 129, 0.06)" }}
+              >
+                {agent.config}
+              </div>
+            </div>
+
+            {agent.altMethod && (
+              <p className="mt-3 font-mono text-xs text-emerald-500/40">
+                {agent.altMethod}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Available tools */}
+      <h2 className="mt-12 font-mono text-lg font-bold text-emerald-400 tracking-wider">
+        Available Tools
+      </h2>
+      <p className="mt-2 font-mono text-xs text-emerald-500/50">
+        Once connected, your AI agent gets access to these tools:
+      </p>
+
+      <div className="mt-6 flex flex-col gap-4">
+        {tools.map((tool) => (
+          <div
+            key={tool.name}
+            className="rounded-lg border border-emerald-500/15 bg-black/40 p-4"
+          >
+            <code className="font-mono text-sm text-emerald-400">{tool.name}</code>
+            <p className="mt-1 font-mono text-xs text-emerald-500/60 leading-relaxed">
+              {tool.description}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* npx alternative */}
+      <div className="mt-12 rounded-lg border border-emerald-500/15 bg-black/40 p-6">
+        <h2 className="font-mono text-sm font-bold text-emerald-300">
+          Without Global Install
+        </h2>
+        <p className="mt-2 font-mono text-xs text-emerald-500/60 leading-relaxed">
+          If you prefer not to install globally, use npx in your MCP config instead:
+        </p>
+        <div
+          className="mt-3 rounded border border-emerald-500/20 bg-black/80 px-4 py-3 font-mono text-sm text-green-400 whitespace-pre overflow-x-auto"
+          style={{ boxShadow: "0 0 20px rgba(16, 185, 129, 0.06)" }}
+        >
+{`{
+  "mcpServers": {
+    "getwired": {
+      "command": "npx",
+      "args": ["-y", "getwired", "mcp"]
+    }
+  }
+}`}
+        </div>
+      </div>
+
+      <div className="mt-12 flex justify-between">
+        <Link
+          href="/docs/test-modes"
+          className="rounded border border-emerald-500/20 px-4 py-2 font-mono text-xs text-emerald-500/60 transition hover:border-emerald-400/50 hover:bg-emerald-400 hover:text-black"
+        >
+          &larr; Test Modes
+        </Link>
+        <Link
+          href="/docs/configuration"
+          className="rounded border border-emerald-500/20 px-4 py-2 font-mono text-xs text-emerald-500/60 transition hover:border-emerald-400/50 hover:bg-emerald-400 hover:text-black"
+        >
+          Next: Configuration &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/docs/reports/page.tsx
+++ b/apps/web/app/docs/reports/page.tsx
@@ -83,10 +83,10 @@ export default function Reports() {
           &larr; Test Modes
         </Link>
         <Link
-          href="/docs/configuration"
+          href="/docs/mcp"
           className="rounded border border-emerald-500/20 px-4 py-2 font-mono text-xs text-emerald-500/60 transition hover:border-emerald-400/50 hover:bg-emerald-400 hover:text-black"
         >
-          Next: Configuration &rarr;
+          Next: MCP &rarr;
         </Link>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -514,6 +514,18 @@
       "resolved": "apps/web",
       "link": true
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -1028,6 +1040,46 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -2495,6 +2547,19 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2506,6 +2571,39 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -2566,6 +2664,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -2582,6 +2704,15 @@
         "esbuild": ">=0.18"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2590,6 +2721,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2727,6 +2887,28 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -2734,6 +2916,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/core-js": {
@@ -2745,6 +2945,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -2772,7 +2989,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2784,6 +3000,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/detect-libc": {
@@ -2805,11 +3030,40 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -2835,6 +3089,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-toolkit": {
@@ -2889,6 +3173,12 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -2897,6 +3187,119 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2922,6 +3325,27 @@
       "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
       "license": "MIT"
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -2932,6 +3356,24 @@
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -2948,6 +3390,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -2958,6 +3409,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2977,12 +3465,93 @@
       "resolved": "packages/cli",
       "link": true
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/indent-string": {
       "version": "5.0.0",
@@ -2995,6 +3564,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ink": {
       "version": "6.8.0",
@@ -3045,6 +3620,24 @@
         }
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
@@ -3075,6 +3668,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3091,6 +3690,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -3100,6 +3708,18 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -3408,6 +4028,61 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -3434,7 +4109,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -3465,6 +4139,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/next": {
@@ -3551,10 +4234,42 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -3570,6 +4285,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/patch-console": {
@@ -3588,6 +4312,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3624,6 +4358,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -3795,11 +4538,63 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
       "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -3849,6 +4644,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3932,6 +4736,28 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3950,6 +4776,57 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -4017,6 +4894,78 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4068,6 +5017,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string-width": {
@@ -4249,6 +5207,15 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -4393,6 +5360,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4419,6 +5400,24 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/web-vitals": {
       "version": "5.2.0",
@@ -4490,6 +5489,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -4517,16 +5522,36 @@
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
     },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "packages/cli": {
       "name": "getwired",
-      "version": "0.0.14",
+      "version": "0.0.16",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@napi-rs/canvas": "^0.1.65",
         "commander": "^13.0.0",
         "ink": "^6.8.0",
         "playwright": "^1.59.1",
-        "react": "^19.0.0"
+        "react": "^19.0.0",
+        "zod": "^4.3.6"
       },
       "bin": {
         "getwired": "dist/cli.js"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,6 +26,47 @@ Run GetWired from the project folder directly. It only tests local apps on `loca
 - `getwired test` runs a testing session against a local app in the current project folder.
 - `getwired report` opens a saved report by id.
 - `getwired dashboard` opens the interactive dashboard.
+- `getwired mcp` starts an MCP server for AI coding agent integration.
+
+## MCP Server
+
+Run `getwired mcp` to start an MCP server that any AI coding agent can connect to. Add this to your agent's config:
+
+**Claude Code** (`~/.claude/settings.json`):
+```json
+{
+  "mcpServers": {
+    "getwired": { "command": "getwired", "args": ["mcp"] }
+  }
+}
+```
+
+**Codex** (`~/.codex/config.toml`):
+```toml
+[mcp_servers.getwired]
+command = "getwired"
+args = ["mcp"]
+```
+
+**Cursor** (`~/.cursor/mcp.json`):
+```json
+{
+  "mcpServers": {
+    "getwired": { "command": "getwired", "args": ["mcp"] }
+  }
+}
+```
+
+**Windsurf** (`~/.codeium/windsurf/mcp_config.json`):
+```json
+{
+  "mcpServers": {
+    "getwired": { "command": "getwired", "args": ["mcp"] }
+  }
+}
+```
+
+**Augment Code**: Open Augment settings > MCP servers, import the same JSON as Claude Code above.
 
 ## Requirements
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,11 +40,13 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/canvas": "^0.1.65",
     "commander": "^13.0.0",
     "ink": "^6.8.0",
     "playwright": "^1.59.1",
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -43,6 +43,15 @@ program
     render(<ReportView reportId={options.id} />);
   });
 
+// MCP server mode (no TUI, communicates over stdio JSON-RPC)
+program
+  .command("mcp")
+  .description("Start MCP server for AI coding agent integration (Claude Code, Cursor, Windsurf, etc.)")
+  .action(async () => {
+    const { startMcpServer } = await import("./mcp/server.js");
+    await startMcpServer();
+  });
+
 // Default: interactive dashboard
 program
   .command("dashboard", { isDefault: true })

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -1,0 +1,25 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerCheckStatus } from "./tools/check-status.js";
+import { registerInit } from "./tools/init-project.js";
+import { registerRunTest } from "./tools/run-test.js";
+import { registerListReports } from "./tools/list-reports.js";
+import { registerGetReport } from "./tools/get-report.js";
+import { registerGetFindings } from "./tools/get-findings.js";
+
+export async function startMcpServer() {
+  const server = new McpServer({
+    name: "getwired",
+    version: "0.0.16",
+  });
+
+  registerCheckStatus(server);
+  registerInit(server);
+  registerRunTest(server);
+  registerListReports(server);
+  registerGetReport(server);
+  registerGetFindings(server);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/packages/cli/src/mcp/tools/check-status.ts
+++ b/packages/cli/src/mcp/tools/check-status.ts
@@ -1,0 +1,84 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { configExists, loadConfig, getReportDir } from "../../config/settings.js";
+import { readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export function registerCheckStatus(server: McpServer) {
+  server.tool(
+    "getwired_check_status",
+    "Check if GetWired is initialized and configured in a project. Call this first to understand the current state.",
+    {
+      project_path: z.string().describe("Absolute path to the project root"),
+    },
+    async ({ project_path }) => {
+      const initialized = configExists(project_path);
+
+      if (!initialized) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  initialized: false,
+                  message:
+                    "GetWired is not initialized in this project. Use getwired_init to set it up.",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      try {
+        const config = await loadConfig(project_path);
+        const reportDir = getReportDir(project_path);
+        let reportCount = 0;
+        if (existsSync(reportDir)) {
+          const entries = await readdir(reportDir, { withFileTypes: true });
+          const dirs = entries.filter((e: { isDirectory(): boolean }) => e.isDirectory());
+          for (const dir of dirs) {
+            const files = await readdir(join(reportDir, dir.name));
+            if (files.some((f: string) => f.endsWith(".json") && f !== "debug.log")) {
+              reportCount++;
+            }
+          }
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  initialized: true,
+                  provider: config.provider,
+                  projectName: config.project.name,
+                  projectUrl: config.project.url ?? null,
+                  deviceProfile: config.testing.deviceProfile,
+                  reportCount,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error reading config: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/cli/src/mcp/tools/get-findings.ts
+++ b/packages/cli/src/mcp/tools/get-findings.ts
@@ -1,0 +1,87 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getReportDir } from "../../config/settings.js";
+import { loadReport, findLatestReport } from "./get-report.js";
+
+export function registerGetFindings(server: McpServer) {
+  server.tool(
+    "getwired_get_findings",
+    "Get test findings filtered by severity or category. Defaults to latest report if no report_id given.",
+    {
+      project_path: z.string().describe("Absolute path to the project root"),
+      report_id: z.string().optional().describe("Report ID (defaults to latest report)"),
+      severity: z
+        .enum(["critical", "high", "medium", "low", "info"])
+        .optional()
+        .describe("Filter by severity level"),
+      category: z
+        .enum(["ui-regression", "functional", "accessibility", "performance", "seo", "console-error"])
+        .optional()
+        .describe("Filter by finding category"),
+    },
+    async ({ project_path, report_id, severity, category }) => {
+      try {
+        const reportDir = getReportDir(project_path);
+        const id = report_id ?? (await findLatestReport(reportDir));
+
+        if (!id) {
+          return {
+            content: [{ type: "text", text: "No reports found. Run getwired_run_test first." }],
+            isError: true,
+          };
+        }
+
+        const report = await loadReport(reportDir, id);
+        if (!report) {
+          return {
+            content: [{ type: "text", text: `Report "${id}" not found.` }],
+            isError: true,
+          };
+        }
+
+        let findings = report.findings;
+        if (severity) findings = findings.filter((f) => f.severity === severity);
+        if (category) findings = findings.filter((f) => f.category === category);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  reportId: report.id,
+                  timestamp: report.timestamp,
+                  totalFindings: report.findings.length,
+                  filteredCount: findings.length,
+                  filters: { severity: severity ?? "all", category: category ?? "all" },
+                  findings: findings.map((f) => ({
+                    id: f.id,
+                    severity: f.severity,
+                    category: f.category,
+                    title: f.title,
+                    description: f.description,
+                    url: f.url ?? null,
+                    device: f.device ?? null,
+                    steps: f.steps ?? [],
+                  })),
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error reading findings: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/cli/src/mcp/tools/get-report.ts
+++ b/packages/cli/src/mcp/tools/get-report.ts
@@ -1,0 +1,90 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getReportDir } from "../../config/settings.js";
+import { readdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { TestReport } from "../../providers/types.js";
+
+/** Strip base64 screenshot data from findings to keep response size manageable. */
+function stripScreenshotData(report: TestReport): TestReport {
+  return {
+    ...report,
+    findings: report.findings.map((f) => ({
+      ...f,
+      // Keep paths but note they're local file paths
+      screenshotPath: f.screenshotPath ?? undefined,
+      diffScreenshotPath: f.diffScreenshotPath ?? undefined,
+    })),
+  };
+}
+
+async function findLatestReport(reportDir: string): Promise<string | null> {
+  if (!existsSync(reportDir)) return null;
+  const entries = await readdir(reportDir, { withFileTypes: true });
+  const dirs = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort()
+    .reverse();
+  return dirs[0] ?? null;
+}
+
+async function loadReport(reportDir: string, reportId: string): Promise<TestReport | null> {
+  const dir = join(reportDir, reportId);
+  if (!existsSync(dir)) return null;
+
+  const files = await readdir(dir);
+  const jsonFile = files.find((f) => f.endsWith(".json") && f !== "debug.log");
+  if (!jsonFile) return null;
+
+  const raw = await readFile(join(dir, jsonFile), "utf-8");
+  return JSON.parse(raw) as TestReport;
+}
+
+export { loadReport, findLatestReport };
+
+export function registerGetReport(server: McpServer) {
+  server.tool(
+    "getwired_get_report",
+    "Get a full test report by ID. Returns all findings, steps, and summary.",
+    {
+      project_path: z.string().describe("Absolute path to the project root"),
+      report_id: z.string().describe("Report ID (e.g. gw-m4x2k1a3-7f2b). Use getwired_list_reports to find IDs."),
+    },
+    async ({ project_path, report_id }) => {
+      try {
+        const reportDir = getReportDir(project_path);
+        const report = await loadReport(reportDir, report_id);
+
+        if (!report) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Report "${report_id}" not found. Use getwired_list_reports to see available reports.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [
+            { type: "text", text: JSON.stringify(stripScreenshotData(report), null, 2) },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error reading report: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/cli/src/mcp/tools/init-project.ts
+++ b/packages/cli/src/mcp/tools/init-project.ts
@@ -1,0 +1,96 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { basename } from "node:path";
+import { configExists, initConfig, saveConfig, loadConfig } from "../../config/settings.js";
+
+export function registerInit(server: McpServer) {
+  server.tool(
+    "getwired_init",
+    "Initialize GetWired configuration in a project. Creates .getwired/config.json with defaults.",
+    {
+      project_path: z.string().describe("Absolute path to the project root"),
+      provider: z
+        .enum(["claude-code", "auggie", "codex", "opencode"])
+        .optional()
+        .describe("AI provider to use (defaults to claude-code)"),
+    },
+    async ({ project_path, provider }) => {
+      if (configExists(project_path)) {
+        const config = await loadConfig(project_path);
+        if (provider && provider !== config.provider) {
+          config.provider = provider;
+          await saveConfig(project_path, config);
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    status: "updated",
+                    message: `Provider updated to ${provider}`,
+                    configPath: `${project_path}/.getwired/config.json`,
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  status: "already_initialized",
+                  message: "GetWired is already initialized in this project.",
+                  configPath: `${project_path}/.getwired/config.json`,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      try {
+        const projectName = basename(project_path);
+        const settings = await initConfig(project_path, projectName);
+        if (provider) {
+          settings.provider = provider;
+          await saveConfig(project_path, settings);
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  status: "initialized",
+                  message: `GetWired initialized in ${project_path}`,
+                  provider: settings.provider,
+                  configPath: `${project_path}/.getwired/config.json`,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error initializing: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/cli/src/mcp/tools/list-reports.ts
+++ b/packages/cli/src/mcp/tools/list-reports.ts
@@ -1,0 +1,85 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getReportDir } from "../../config/settings.js";
+import { readdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { TestReport } from "../../providers/types.js";
+
+export function registerListReports(server: McpServer) {
+  server.tool(
+    "getwired_list_reports",
+    "List available test reports with summaries. Returns report IDs, timestamps, and pass/fail counts.",
+    {
+      project_path: z.string().describe("Absolute path to the project root"),
+      limit: z.number().optional().describe("Maximum number of reports to return (default 10)"),
+    },
+    async ({ project_path, limit }) => {
+      const max = limit ?? 10;
+      const reportDir = getReportDir(project_path);
+
+      if (!existsSync(reportDir)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ reports: [], message: "No reports directory found." }, null, 2),
+            },
+          ],
+        };
+      }
+
+      try {
+        const entries = await readdir(reportDir, { withFileTypes: true });
+        const dirs = entries
+          .filter((e) => e.isDirectory())
+          .map((e) => e.name)
+          .sort()
+          .reverse()
+          .slice(0, max);
+
+        const summaries = [];
+        for (const dir of dirs) {
+          try {
+            // Reports are saved as <id>.json inside the directory
+            const files = await readdir(join(reportDir, dir));
+            const jsonFile = files.find((f) => f.endsWith(".json") && f !== "debug.log");
+            if (!jsonFile) continue;
+
+            const raw = await readFile(join(reportDir, dir, jsonFile), "utf-8");
+            const report: TestReport = JSON.parse(raw);
+            summaries.push({
+              id: report.id,
+              timestamp: report.timestamp,
+              provider: report.provider,
+              url: report.context.url ?? null,
+              passed: report.summary.passed,
+              failed: report.summary.failed,
+              warnings: report.summary.warnings,
+              duration: report.summary.duration,
+              findingCount: report.findings.length,
+            });
+          } catch {
+            // Skip malformed reports
+          }
+        }
+
+        return {
+          content: [
+            { type: "text", text: JSON.stringify({ reports: summaries }, null, 2) },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error listing reports: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/cli/src/mcp/tools/run-test.ts
+++ b/packages/cli/src/mcp/tools/run-test.ts
@@ -1,0 +1,186 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { configExists } from "../../config/settings.js";
+import type {
+  TestReport,
+  TestFinding,
+  TestPersona,
+} from "../../providers/types.js";
+import type { OrchestratorCallbacks, TestStep } from "../../orchestrator/index.js";
+
+/**
+ * Temporarily redirect all stdout writes to stderr so that stray console.log
+ * calls from the orchestrator (e.g. ensureAgentBrowser) don't corrupt the
+ * MCP JSON-RPC stream on stdout.
+ */
+function redirectStdout(): () => void {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = function (chunk: any, ...args: any[]) {
+    return (process.stderr.write as any).call(process.stderr, chunk, ...args);
+  } as any;
+  return () => {
+    process.stdout.write = originalWrite;
+  };
+}
+
+export function registerRunTest(server: McpServer) {
+  server.tool(
+    "getwired_run_test",
+    "Run a full AI-powered test session on a web app, native app, or desktop app. This is the main testing tool — it launches a browser, navigates the app, and reports bugs, regressions, and security issues. Takes 2-5 minutes.",
+    {
+      project_path: z.string().describe("Absolute path to the project root"),
+      url: z
+        .string()
+        .optional()
+        .describe("Local app URL to test (e.g. http://localhost:3000). Uses config URL if not provided."),
+      scope: z
+        .string()
+        .optional()
+        .describe("Scope of testing (e.g. auth, checkout, navigation)"),
+      persona: z
+        .enum(["standard", "hacky", "old-man"])
+        .optional()
+        .describe("Test persona: standard (normal user), hacky (security-focused), old-man (confused user)"),
+      platform: z
+        .enum(["android", "ios", "electron"])
+        .optional()
+        .describe("Native platform. Omit for web browser testing."),
+      commit: z
+        .string()
+        .optional()
+        .describe("Test against a specific commit for visual regression"),
+      pr: z
+        .string()
+        .optional()
+        .describe("Test against a specific PR for visual regression"),
+      device: z
+        .enum(["desktop", "mobile", "both"])
+        .optional()
+        .describe("Device profile (default: both)"),
+    },
+    async ({ project_path, url, scope, persona, platform, commit, pr, device }) => {
+      if (!configExists(project_path)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "GetWired is not initialized. Run getwired_init first.",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const logs: string[] = [];
+      const findings: TestFinding[] = [];
+
+      const callbacks: OrchestratorCallbacks = {
+        onPhaseChange: (phase, msg) => {
+          logs.push(`[${phase}] ${msg}`);
+          // Write progress to stderr so MCP client logs show progress
+          console.error(`[getwired] ${phase}: ${msg}`);
+        },
+        onStepUpdate: (_steps: TestStep[]) => {},
+        onFinding: (finding) => {
+          findings.push(finding);
+          console.error(`[getwired] Finding: [${finding.severity}] ${finding.title}`);
+        },
+        onLog: (msg) => {
+          logs.push(msg);
+        },
+      };
+
+      // Redirect stdout to stderr during test execution to protect MCP protocol
+      const restoreStdout = redirectStdout();
+
+      try {
+        let report: TestReport;
+
+        if (platform === "android" || platform === "ios") {
+          const { runNativeTestSession } = await import("../../orchestrator/index.js");
+          report = await runNativeTestSession(
+            project_path,
+            {
+              url,
+              scope,
+              persona: persona as TestPersona | undefined,
+              nativePlatform: platform,
+            },
+            callbacks,
+          );
+        } else if (platform === "electron") {
+          const { runDesktopTestSession } = await import("../../orchestrator/index.js");
+          report = await runDesktopTestSession(
+            project_path,
+            {
+              url,
+              scope,
+              persona: persona as TestPersona | undefined,
+              desktopPlatform: "electron",
+            },
+            callbacks,
+          );
+        } else {
+          const { runTestSession } = await import("../../orchestrator/index.js");
+          report = await runTestSession(
+            project_path,
+            {
+              url,
+              commitId: commit,
+              prId: pr,
+              scope,
+              persona: persona as TestPersona | undefined,
+            },
+            callbacks,
+          );
+        }
+
+        // Strip large binary data from response
+        const cleanReport = {
+          id: report.id,
+          timestamp: report.timestamp,
+          provider: report.provider,
+          summary: report.summary,
+          findings: report.findings.map((f) => ({
+            id: f.id,
+            severity: f.severity,
+            category: f.category,
+            title: f.title,
+            description: f.description,
+            url: f.url ?? null,
+            device: f.device ?? null,
+            steps: f.steps ?? [],
+            screenshotPath: f.screenshotPath ?? null,
+          })),
+          notes: report.notes,
+          execution: report.execution ?? null,
+        };
+
+        return {
+          content: [
+            { type: "text", text: JSON.stringify(cleanReport, null, 2) },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  error: err instanceof Error ? err.message : String(err),
+                  logs: logs.slice(-20), // Last 20 log entries for debugging
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
+      } finally {
+        restoreStdout();
+      }
+    },
+  );
+}


### PR DESCRIPTION
Implement Model Context Protocol (MCP) server mode to enable AI coding agents (Claude Code, Cursor, Windsurf, Codex, Augment) to run tests and manage GetWired directly. Add `getwired mcp` command that starts a JSON-RPC server over stdio with six tools: check project status, initialize configuration, run tests, list reports, get full reports, and filter findings. Update documentation across README, CLI docs, and web docs with setup instructions for each supported agent. Add MCP SDK and Zod dependencies for schema validation and protocol implementation.