### PR TITLE
fix(cli): keep Auggie stderr out of TUI output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist/
 
 # cursor / editor
 .cursor/
+AGENTS.md
 
 # debug
 npm-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,0 @@
-## Learned User Preferences
-
-- Keep Cursor local/editor data under `.cursor/` out of git; do not commit hook state or other files from that directory.
-
-## Learned Workspace Facts
-
-- GitHub repository: GetWiredDev/getwired.
-- The Augment MCP `augment_code_search` tool on the `user-auggie` server does not have this repository in its remote index (queries return not found), and that MCP surface exposes no tool to register or index repos from the agent.


### PR DESCRIPTION
## Summary

- **Auggie provider:** Stop merging stderr into streamed provider output so MCP/tool init noise does not appear as test output in the TUI (short-term mitigation for GetWiredDev/getwired#8).
- **Hardening:** Add stderr error handling and bounded tail buffering that truncates incoming stderr chunks before concatenation to avoid temporary memory spikes.
- **Repo hygiene:** Add `.cursor/` and `AGENTS.md` to `.gitignore`; remove tracked Cursor hook state and `AGENTS.md` from the PR.

## Testing

- `npm run lint` in `packages/cli` *(currently fails due to pre-existing missing deps/types in this branch: `zod`, `@modelcontextprotocol/sdk`)*
- `npm run test:cli-regression` from repo root *(currently fails for the same missing runtime deps)*

Related to #8 (does not implement long-lived provider session / single MCP init per run).