### PR TITLE
fix(security): resolve all Dependabot and CodeQL security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,9 +729,9 @@
       "link": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -3589,9 +3589,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/packages/cli/src/desktop/electron-app.ts
+++ b/packages/cli/src/desktop/electron-app.ts
@@ -124,10 +124,10 @@ export async function getElectronUIStructure(session: ElectronSession): Promise<
         const value = element.getAttribute(attr);
         if (!value) continue;
         if (attr === "id") return "#" + CSS.escape(value);
-        return "[" + attr + "=\"" + value.replace(/"/g, '\\"') + "\"]";
+        return "[" + attr + "=\"" + value.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + "\"]";
       }
       if (element.tagName === "A" && element.getAttribute("href")) {
-        return "a[href=\"" + element.getAttribute("href")!.replace(/"/g, '\\"') + "\"]";
+        return "a[href=\"" + element.getAttribute("href")!.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + "\"]";
       }
       return null;
     };


### PR DESCRIPTION
## Summary

Addresses all open security alerts in a single PR.

### npm audit vulnerabilities (2 moderate → 0)
- **hono** 4.12.10 → 4.12.12 — fixes cookie handling, IP restriction bypass, path traversal, middleware bypass (5 CVEs)
- **@hono/node-server** 1.19.12 → 1.19.13 — fixes middleware bypass via repeated slashes in serveStatic

### CodeQL code scanning alerts
- **Alerts #1, #2** (High) — Fixed incomplete string escaping in `packages/cli/src/desktop/electron-app.ts` — added backslash escaping before quote escaping in CSS selector builder
- **Alerts #3, #5** (Medium) — Added explicit `permissions: contents: read` to `.github/workflows/ci.yml` to restrict GITHUB_TOKEN scope

### Files changed
- `package-lock.json` — lockfile-only dep updates
- `packages/cli/src/desktop/electron-app.ts` — string escaping fix
- `.github/workflows/ci.yml` — permissions block added

### Verification
- `npm audit` → 0 vulnerabilities
- `npx tsc --noEmit` → clean
- All tests passing
