### PR TITLE
chore(deps): patch protobufjs, hono, dompurify security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3102,9 +3102,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3589,9 +3589,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4541,9 +4541,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

Resolves all three open GitHub security advisories by bumping affected transitive dependencies to patched versions. Only `package-lock.json` changes — no source code modified.

## Advisories Fixed

| Advisory | Package | Before → After |
|---|---|---|
| [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) (critical) | `protobufjs` | 7.5.4 → **7.5.5** |
| [GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375) (moderate) | `hono` | 4.12.12 → **4.12.14** |
| [GHSA-39q2-94rc-95cp](https://github.com/advisories/GHSA-39q2-94rc-95cp) (moderate) | `dompurify` | 3.3.3 → **3.4.0** |

## Verification

- `npm audit` — **0 vulnerabilities** (info/low/moderate/high/critical all 0)
- `npm ls` — confirmed resolved versions above
- `git diff --name-only` — only `package-lock.json` modified
- `npm run lint` — ✅ PASS
- `npm run build` — ✅ PASS (Next 15.5.15 web + tsup CLI)
- `npm run test --workspace ./packages/cli` — ✅ PASS (50/50, 11 suites, 0 failures)

## Scope

- ✅ Security-only lockfile bumps
- ❌ Non-security upgrades intentionally deferred (Next 16, Ink 7, Commander 14, TS 6, etc.)

## Rollback

`git revert ba3d68f` or `git checkout main -- package-lock.json && npm ci`


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author